### PR TITLE
Hide internal api

### DIFF
--- a/src/arp/data/DataGroup.hx
+++ b/src/arp/data/DataGroup.hx
@@ -45,7 +45,7 @@ class DataGroup implements IArpObject {
 	public var arpHeat(get, never):ArpHeat;
 	inline private function get_arpHeat():ArpHeat return this._arpSlot.heat;
 
-	public function arpInit(slot:ArpUntypedSlot, seed:ArpSeed = null):IArpObject {
+	public function __arp_init(slot:ArpUntypedSlot, seed:ArpSeed = null):IArpObject {
 		this._arpDomain = slot.domain;
 		this._arpSlot = slot;
 		if (seed != null) {
@@ -56,19 +56,19 @@ class DataGroup implements IArpObject {
 		return this;
 	}
 
-	public function arpHeatLater():Void {
+	public function __arp_heatLaterDeps():Void {
 		for (slot in this.children) this.arpDomain.heatLater(slot);
 	}
 
-	public function arpHeatUp():Bool {
+	public function __arp_heatUpNow():Bool {
 		return true;
 	}
 
-	public function arpHeatDown():Bool {
+	public function __arp_heatDownNow():Bool {
 		return true;
 	}
 
-	public function arpDispose():Void {
+	public function __arp_dispose():Void {
 		for (slot in this.children) slot.delReference();
 		this._arpSlot = null;
 		this._arpDomain = null;

--- a/src/arp/domain/ArpDirectory.hx
+++ b/src/arp/domain/ArpDirectory.hx
@@ -77,7 +77,7 @@ class ArpDirectory {
 	private function addObject<T:IArpObject>(arpObj:T):T {
 		var slot:ArpSlot<T> = this.getOrCreateSlot(arpObj.arpType);
 		slot.value = arpObj;
-		arpObj.arpInit(slot);
+		arpObj.__arp_init(slot);
 		return arpObj;
 	}
 

--- a/src/arp/domain/ArpDomain.hx
+++ b/src/arp/domain/ArpDomain.hx
@@ -187,7 +187,7 @@ class ArpDomain {
 	private function addObject<T:IArpObject>(arpObj:T, sid:ArpSid = null):T {
 		var slot:ArpSlot<T> = (sid != null) ? this.getOrCreateSlot(sid) : this.allocSlot(sid);
 		slot.value = arpObj;
-		arpObj.arpInit(slot);
+		arpObj.__arp_init(slot);
 		return arpObj;
 	}
 
@@ -208,7 +208,7 @@ class ArpDomain {
 	}
 
 	public function heatDown(slot:ArpUntypedSlot):Void {
-		slot.value.arpHeatDown();
+		slot.value.__arp_heatDownNow();
 		slot.heat = ArpHeat.Cold;
 	}
 
@@ -225,7 +225,7 @@ class ArpDomain {
 	inline private function get_tasksWaiting():Int return this.prepareQueue.tasksWaiting;
 
 	public var onPrepareComplete(get, never):IArpSignalOut<Int>;
-	inline private function get_onPrepareComplete():IArpSignalOut<Int> return this.prepareQueue.onProgress;
+	inline private function get_onPrepareComplete():IArpSignalOut<Int> return this.prepareQueue.onComplete;
 
 	public var onPrepareError(get, never):IArpSignalOut<Dynamic>;
 	inline private function get_onPrepareError():IArpSignalOut<Dynamic> return this.prepareQueue.onError;

--- a/src/arp/domain/ArpUntypedSlot.hx
+++ b/src/arp/domain/ArpUntypedSlot.hx
@@ -46,7 +46,7 @@ class ArpUntypedSlot {
 	/* inline */ public function delReference():ArpUntypedSlot {
 		if (--this._refCount <= 0) {
 			if (this._value != null) {
-				this._value.arpDispose();
+				this._value.__arp_dispose();
 				this._value = null;
 			}
 			this._domain.freeSlot(this);

--- a/src/arp/domain/IArpObject.hx
+++ b/src/arp/domain/IArpObject.hx
@@ -16,12 +16,12 @@ interface IArpObject extends IPersistable /* extends IArpObjectImpl */ {
 	var arpSlot(get, never):ArpUntypedSlot;
 	var arpHeat(get, never):ArpHeat;
 
-	@:noDoc @:noCompletion function arpInit(slot:ArpUntypedSlot, seed:ArpSeed = null):IArpObject;
-	@:noDoc @:noCompletion function arpDispose():Void;
+	@:noDoc @:noCompletion function __arp_init(slot:ArpUntypedSlot, seed:ArpSeed = null):IArpObject;
+	@:noDoc @:noCompletion function __arp_dispose():Void;
 	function arpClone():IArpObject;
 	function arpCopyFrom(source:IArpObject):IArpObject;
 
-	@:noDoc @:noCompletion function arpHeatLater():Void;
-	@:noDoc @:noCompletion function arpHeatUp():Bool;
-	@:noDoc @:noCompletion function arpHeatDown():Bool;
+	@:noDoc @:noCompletion function __arp_heatLaterDeps():Void;
+	@:noDoc @:noCompletion function __arp_heatUpNow():Bool;
+	@:noDoc @:noCompletion function __arp_heatDownNow():Bool;
 }

--- a/src/arp/domain/factory/ArpObjectFactory.hx
+++ b/src/arp/domain/factory/ArpObjectFactory.hx
@@ -33,7 +33,7 @@ class ArpObjectFactory<T:IArpObject> {
 
 	public function arpInit(slot:ArpSlot<T>, seed:ArpSeed):T {
 		var arpObject:T = alloc(seed);
-		if (arpObject.arpInit(slot, seed) == null) return null;
+		if (arpObject.__arp_init(slot, seed) == null) return null;
 		return arpObject;
 	}
 }

--- a/src/arp/domain/prepare/PrepareTask.hx
+++ b/src/arp/domain/prepare/PrepareTask.hx
@@ -44,12 +44,12 @@ class PrepareTask implements IPrepareTask {
 
 		if (!this.preparePropagated) {
 			// trigger dependency prepare
-			this._slot.value.arpHeatLater();
+			this._slot.value.__arp_heatLaterDeps();
 			this.preparePropagated = true;
 		}
 
 		// try to heat up myself
-		if (!this._slot.value.arpHeatUp()) {
+		if (!this._slot.value.__arp_heatUpNow()) {
 			this.domain.log("arp_debug_prepare", 'PrepareTask.run(): waiting depending prepares: ${this._slot}');
 			return TaskStatus.Stalled;
 		}

--- a/src/arp/impl/IArpObjectImpl.hx
+++ b/src/arp/impl/IArpObjectImpl.hx
@@ -1,7 +1,7 @@
 package arp.impl;
 
 interface IArpObjectImpl {
-	@:noDoc @:noCompletion function arpHeatUp():Bool;
-	@:noDoc @:noCompletion function arpHeatDown():Bool;
-	@:noDoc @:noCompletion function arpDispose():Void;
+	@:noDoc @:noCompletion function __arp_heatUpNow():Bool;
+	@:noDoc @:noCompletion function __arp_heatDownNow():Bool;
+	@:noDoc @:noCompletion function __arp_dispose():Void;
 }

--- a/src/arp/macro/IMacroArpField.hx
+++ b/src/arp/macro/IMacroArpField.hx
@@ -13,9 +13,9 @@ interface IMacroArpField {
 
 	public function buildField(outFields:Array<Field>):Void;
 	public function buildInitBlock(initBlock:Array<Expr>):Void;
-	public function buildHeatLaterBlock(heatLaterBlock:Array<Expr>):Void;
-	public function buildHeatUpBlock(heatUpBlock:Array<Expr>):Void;
-	public function buildHeatDownBlock(heatDownBlock:Array<Expr>):Void;
+	public function buildHeatLaterDepsBlock(heatLaterDepsBlock:Array<Expr>):Void;
+	public function buildHeatUpNowBlock(heatUpNowBlock:Array<Expr>):Void;
+	public function buildHeatDownNowBlock(heatDownNowBlock:Array<Expr>):Void;
 	public function buildDisposeBlock(initBlock:Array<Expr>):Void;
 	public function buildConsumeSeedElementBlock(cases:MacroArpSwitchBlock):Void;
 	public function buildReadSelfBlock(fieldBlock:Array<Expr>):Void;

--- a/src/arp/macro/MacroArpUtil.hx
+++ b/src/arp/macro/MacroArpUtil.hx
@@ -13,6 +13,9 @@ class MacroArpUtil {
 	inline public static var IArpObject = "arp.domain.IArpObject";
 	inline public static var IArpObjectImpl = "arp.impl.IArpObjectImpl";
 
+	inline public static function __arpReserved(value:String):String return '__arp_$value';
+	inline public static function __arpGenerated(value:String):String return '__arp__$value';
+
 	public static function error(message:String, pos:Position):Void {
 		Context.error(message, pos);
 #if arp_macro_debug

--- a/src/arp/macro/fields/MacroArpObjectField.hx
+++ b/src/arp/macro/fields/MacroArpObjectField.hx
@@ -55,18 +55,18 @@ class MacroArpObjectField extends MacroArpFieldBase implements IMacroArpField {
 		}
 	}
 
-	public function buildHeatLaterBlock(heatLaterBlock:Array<Expr>):Void {
+	public function buildHeatLaterDepsBlock(heatLaterDepsBlock:Array<Expr>):Void {
 		if (!this.arpHasBarrier) return;
-		heatLaterBlock.push(macro @:pos(this.nativePos) { this._arpDomain.heatLater(this.$iNativeSlot, $v{arpBarrierRequired}); });
+		heatLaterDepsBlock.push(macro @:pos(this.nativePos) { this._arpDomain.heatLater(this.$iNativeSlot, $v{arpBarrierRequired}); });
 	}
 
-	public function buildHeatUpBlock(heatUpBlock:Array<Expr>):Void {
+	public function buildHeatUpNowBlock(heatUpNowBlock:Array<Expr>):Void {
 		if (!this.arpHasBarrier) return;
-		heatUpBlock.push(macro @:pos(this.nativePos) { if (this.$iNativeSlot.heat != arp.domain.ArpHeat.Warm) return false; });
+		heatUpNowBlock.push(macro @:pos(this.nativePos) { if (this.$iNativeSlot.heat != arp.domain.ArpHeat.Warm) return false; });
 	}
 
-	public function buildHeatDownBlock(heatDownBlock:Array<Expr>):Void {
-		heatDownBlock.push(macro @:pos(this.nativePos) { null; });
+	public function buildHeatDownNowBlock(heatDownNowBlock:Array<Expr>):Void {
+		heatDownNowBlock.push(macro @:pos(this.nativePos) { null; });
 	}
 
 	public function buildDisposeBlock(disposeBlock:Array<Expr>):Void {

--- a/src/arp/macro/fields/MacroArpValueField.hx
+++ b/src/arp/macro/fields/MacroArpValueField.hx
@@ -47,20 +47,16 @@ class MacroArpValueField extends MacroArpFieldBase implements IMacroArpField {
 		}
 	}
 
-	public function buildHeatLaterBlock(heatLaterBlock:Array<Expr>):Void {
-		heatLaterBlock.push(macro @:pos(this.nativePos) { null; });
+	public function buildHeatLaterDepsBlock(heatLaterDepsBlock:Array<Expr>):Void {
 	}
 
-	public function buildHeatUpBlock(heatUpBlock:Array<Expr>):Void {
-		heatUpBlock.push(macro @:pos(this.nativePos) { null; });
+	public function buildHeatUpNowBlock(heatUpNowBlock:Array<Expr>):Void {
 	}
 
-	public function buildHeatDownBlock(heatDownBlock:Array<Expr>):Void {
-		heatDownBlock.push(macro @:pos(this.nativePos) { null; });
+	public function buildHeatDownNowBlock(heatDownNowBlock:Array<Expr>):Void {
 	}
 
 	public function buildDisposeBlock(disposeBlock:Array<Expr>):Void {
-		disposeBlock.push(macro @:pos(this.nativePos) { null; });
 	}
 
 	public function buildConsumeSeedElementBlock(cases:MacroArpSwitchBlock):Void {

--- a/src/arp/macro/fields/base/MacroArpFieldBase.hx
+++ b/src/arp/macro/fields/base/MacroArpFieldBase.hx
@@ -47,7 +47,7 @@ class MacroArpFieldBase {
 	private var iNativeSlot(get, never):String;
 	private function get_iNativeSlot():String return this.nativeField.name + "Slot";
 	private var i_nativeName(get, never):String;
-	private function get_i_nativeName():String return "__arp__" + this.iNativeName;
+	private function get_i_nativeName():String return MacroArpUtil.__arpGenerated(this.iNativeName);
 	private var iGet_nativeName(get, never):String;
 	private function get_iGet_nativeName():String return "get_" + this.iNativeName;
 	private var iSet_nativeName(get, never):String;

--- a/src/arp/macro/fields/ds/MacroArpObjectListField.hx
+++ b/src/arp/macro/fields/ds/MacroArpObjectListField.hx
@@ -39,18 +39,17 @@ class MacroArpObjectListField extends MacroArpObjectCollectionFieldBase implemen
 		if (!concreteDs) _nativeType = coerce(super.nativeType);
 	}
 
-	public function buildHeatLaterBlock(heatLaterBlock:Array<Expr>):Void {
+	public function buildHeatLaterDepsBlock(heatLaterDepsBlock:Array<Expr>):Void {
 		if (!this.arpHasBarrier) return;
-		heatLaterBlock.push(macro @:pos(this.nativePos) { for (slot in this.$i_nativeName.slotList) this._arpDomain.heatLater(slot, $v{arpBarrierRequired}); });
+		heatLaterDepsBlock.push(macro @:pos(this.nativePos) { for (slot in this.$i_nativeName.slotList) this._arpDomain.heatLater(slot, $v{arpBarrierRequired}); });
 	}
 
-	public function buildHeatUpBlock(heatUpBlock:Array<Expr>):Void {
+	public function buildHeatUpNowBlock(heatUpNowBlock:Array<Expr>):Void {
 		if (!this.arpHasBarrier) return;
-		heatUpBlock.push(macro @:pos(this.nativePos) { if (this.$i_nativeName.heat != arp.domain.ArpHeat.Warm) return false; });
+		heatUpNowBlock.push(macro @:pos(this.nativePos) { if (this.$i_nativeName.heat != arp.domain.ArpHeat.Warm) return false; });
 	}
 
-	public function buildHeatDownBlock(heatDownBlock:Array<Expr>):Void {
-		heatDownBlock.push(macro @:pos(this.nativePos) { null; });
+	public function buildHeatDownNowBlock(heatDownNowBlock:Array<Expr>):Void {
 	}
 
 	public function buildDisposeBlock(disposeBlock:Array<Expr>):Void {

--- a/src/arp/macro/fields/ds/MacroArpObjectMapField.hx
+++ b/src/arp/macro/fields/ds/MacroArpObjectMapField.hx
@@ -39,18 +39,17 @@ class MacroArpObjectMapField extends MacroArpObjectCollectionFieldBase implement
 		if (!concreteDs) _nativeType = coerce(super.nativeType);
 	}
 
-	public function buildHeatLaterBlock(heatLaterBlock:Array<Expr>):Void {
+	public function buildHeatLaterDepsBlock(heatLaterDepsBlock:Array<Expr>):Void {
 		if (!this.arpHasBarrier) return;
-		heatLaterBlock.push(macro @:pos(this.nativePos) { for (slot in this.$i_nativeName.slotMap) this._arpDomain.heatLater(slot, $v{arpBarrierRequired}); });
+		heatLaterDepsBlock.push(macro @:pos(this.nativePos) { for (slot in this.$i_nativeName.slotMap) this._arpDomain.heatLater(slot, $v{arpBarrierRequired}); });
 	}
 
-	public function buildHeatUpBlock(heatUpBlock:Array<Expr>):Void {
+	public function buildHeatUpNowBlock(heatUpNowBlock:Array<Expr>):Void {
 		if (!this.arpHasBarrier) return;
-		heatUpBlock.push(macro @:pos(this.nativePos) { if (this.$i_nativeName.heat != arp.domain.ArpHeat.Warm) return false; });
+		heatUpNowBlock.push(macro @:pos(this.nativePos) { if (this.$i_nativeName.heat != arp.domain.ArpHeat.Warm) return false; });
 	}
 
-	public function buildHeatDownBlock(heatDownBlock:Array<Expr>):Void {
-		heatDownBlock.push(macro @:pos(this.nativePos) { null; });
+	public function buildHeatDownNowBlock(heatDownNowBlock:Array<Expr>):Void {
 	}
 
 	public function buildDisposeBlock(disposeBlock:Array<Expr>):Void {

--- a/src/arp/macro/fields/ds/MacroArpObjectOmapField.hx
+++ b/src/arp/macro/fields/ds/MacroArpObjectOmapField.hx
@@ -39,18 +39,17 @@ class MacroArpObjectOmapField extends MacroArpObjectCollectionFieldBase implemen
 		if (!concreteDs) _nativeType = coerce(super.nativeType);
 	}
 
-	public function buildHeatLaterBlock(heatLaterBlock:Array<Expr>):Void {
+	public function buildHeatLaterDepsBlock(heatLaterDepsBlock:Array<Expr>):Void {
 		if (!this.arpHasBarrier) return;
-		heatLaterBlock.push(macro @:pos(this.nativePos) { for (slot in this.$i_nativeName.slotOmap) this._arpDomain.heatLater(slot, $v{arpBarrierRequired}); });
+		heatLaterDepsBlock.push(macro @:pos(this.nativePos) { for (slot in this.$i_nativeName.slotOmap) this._arpDomain.heatLater(slot, $v{arpBarrierRequired}); });
 	}
 
-	public function buildHeatUpBlock(heatUpBlock:Array<Expr>):Void {
+	public function buildHeatUpNowBlock(heatUpNowBlock:Array<Expr>):Void {
 		if (!this.arpHasBarrier) return;
-		heatUpBlock.push(macro @:pos(this.nativePos) { if (this.$i_nativeName.heat != arp.domain.ArpHeat.Warm) return false; });
+		heatUpNowBlock.push(macro @:pos(this.nativePos) { if (this.$i_nativeName.heat != arp.domain.ArpHeat.Warm) return false; });
 	}
 
-	public function buildHeatDownBlock(heatDownBlock:Array<Expr>):Void {
-		heatDownBlock.push(macro @:pos(this.nativePos) { null; });
+	public function buildHeatDownNowBlock(heatDownNowBlock:Array<Expr>):Void {
 	}
 
 	public function buildDisposeBlock(disposeBlock:Array<Expr>):Void {

--- a/src/arp/macro/fields/ds/MacroArpObjectSetField.hx
+++ b/src/arp/macro/fields/ds/MacroArpObjectSetField.hx
@@ -39,18 +39,17 @@ class MacroArpObjectSetField extends MacroArpObjectCollectionFieldBase implement
 		if (!concreteDs) _nativeType = coerce(super.nativeType);
 	}
 
-	public function buildHeatLaterBlock(heatLaterBlock:Array<Expr>):Void {
+	public function buildHeatLaterDepsBlock(heatLaterDepsBlock:Array<Expr>):Void {
 		if (!this.arpHasBarrier) return;
-		heatLaterBlock.push(macro @:pos(this.nativePos) { for (slot in this.$i_nativeName.slotSet) this._arpDomain.heatLater(slot, $v{arpBarrierRequired}); });
+		heatLaterDepsBlock.push(macro @:pos(this.nativePos) { for (slot in this.$i_nativeName.slotSet) this._arpDomain.heatLater(slot, $v{arpBarrierRequired}); });
 	}
 
-	public function buildHeatUpBlock(heatUpBlock:Array<Expr>):Void {
+	public function buildHeatUpNowBlock(heatUpNowBlock:Array<Expr>):Void {
 		if (!this.arpHasBarrier) return;
-		heatUpBlock.push(macro @:pos(this.nativePos) { if (this.$i_nativeName.heat != arp.domain.ArpHeat.Warm) return false; });
+		heatUpNowBlock.push(macro @:pos(this.nativePos) { if (this.$i_nativeName.heat != arp.domain.ArpHeat.Warm) return false; });
 	}
 
-	public function buildHeatDownBlock(heatDownBlock:Array<Expr>):Void {
-		heatDownBlock.push(macro @:pos(this.nativePos) { null; });
+	public function buildHeatDownNowBlock(heatDownNowBlock:Array<Expr>):Void {
 	}
 
 	public function buildDisposeBlock(disposeBlock:Array<Expr>):Void {

--- a/src/arp/macro/fields/ds/MacroArpValueListField.hx
+++ b/src/arp/macro/fields/ds/MacroArpValueListField.hx
@@ -21,20 +21,16 @@ class MacroArpValueListField extends MacroArpValueCollectionFieldBase implements
 		super(fieldDef, type, concreteDs);
 	}
 
-	public function buildHeatLaterBlock(heatLaterBlock:Array<Expr>):Void {
-		heatLaterBlock.push(macro @:pos(this.nativePos) { null; });
+	public function buildHeatLaterDepsBlock(heatLaterDepsBlock:Array<Expr>):Void {
 	}
 
-	public function buildHeatUpBlock(heatUpBlock:Array<Expr>):Void {
-		heatUpBlock.push(macro @:pos(this.nativePos) { null; });
+	public function buildHeatUpNowBlock(heatUpNowBlock:Array<Expr>):Void {
 	}
 
-	public function buildHeatDownBlock(heatDownBlock:Array<Expr>):Void {
-		heatDownBlock.push(macro @:pos(this.nativePos) { null; });
+	public function buildHeatDownNowBlock(heatDownNowBlock:Array<Expr>):Void {
 	}
 
 	public function buildDisposeBlock(initBlock:Array<Expr>):Void {
-		initBlock.push(macro @:pos(this.nativePos) { null; });
 	}
 
 	public function buildConsumeSeedElementBlock(cases:MacroArpSwitchBlock):Void {

--- a/src/arp/macro/fields/ds/MacroArpValueMapField.hx
+++ b/src/arp/macro/fields/ds/MacroArpValueMapField.hx
@@ -21,20 +21,16 @@ class MacroArpValueMapField extends MacroArpValueCollectionFieldBase implements 
 		super(fieldDef, type, concreteDs);
 	}
 
-	public function buildHeatLaterBlock(heatLaterBlock:Array<Expr>):Void {
-		heatLaterBlock.push(macro @:pos(this.nativePos) { null; });
+	public function buildHeatLaterDepsBlock(heatLaterDepsBlock:Array<Expr>):Void {
 	}
 
-	public function buildHeatUpBlock(heatUpBlock:Array<Expr>):Void {
-		heatUpBlock.push(macro @:pos(this.nativePos) { null; });
+	public function buildHeatUpNowBlock(heatUpNowBlock:Array<Expr>):Void {
 	}
 
-	public function buildHeatDownBlock(heatDownBlock:Array<Expr>):Void {
-		heatDownBlock.push(macro @:pos(this.nativePos) { null; });
+	public function buildHeatDownNowBlock(heatDownNowBlock:Array<Expr>):Void {
 	}
 
 	public function buildDisposeBlock(initBlock:Array<Expr>):Void {
-		initBlock.push(macro @:pos(this.nativePos) { null; } );
 	}
 
 	public function buildConsumeSeedElementBlock(cases:MacroArpSwitchBlock):Void {

--- a/src/arp/macro/fields/ds/MacroArpValueOmapField.hx
+++ b/src/arp/macro/fields/ds/MacroArpValueOmapField.hx
@@ -21,20 +21,16 @@ class MacroArpValueOmapField extends MacroArpValueCollectionFieldBase implements
 		super(fieldDef, type, concreteDs);
 	}
 
-	public function buildHeatLaterBlock(heatLaterBlock:Array<Expr>):Void {
-		heatLaterBlock.push(macro @:pos(this.nativePos) { null; });
+	public function buildHeatLaterDepsBlock(heatLaterDepsBlock:Array<Expr>):Void {
 	}
 
-	public function buildHeatUpBlock(heatUpBlock:Array<Expr>):Void {
-		heatUpBlock.push(macro @:pos(this.nativePos) { null; });
+	public function buildHeatUpNowBlock(heatUpNowBlock:Array<Expr>):Void {
 	}
 
-	public function buildHeatDownBlock(heatDownBlock:Array<Expr>):Void {
-		heatDownBlock.push(macro @:pos(this.nativePos) { null; });
+	public function buildHeatDownNowBlock(heatDownNowBlock:Array<Expr>):Void {
 	}
 
 	public function buildDisposeBlock(initBlock:Array<Expr>):Void {
-		initBlock.push(macro @:pos(this.nativePos) { null; } );
 	}
 
 	public function buildConsumeSeedElementBlock(cases:MacroArpSwitchBlock):Void {

--- a/src/arp/macro/fields/ds/MacroArpValueSetField.hx
+++ b/src/arp/macro/fields/ds/MacroArpValueSetField.hx
@@ -21,20 +21,16 @@ class MacroArpValueSetField extends MacroArpValueCollectionFieldBase implements 
 		super(fieldDef, type, concreteDs);
 	}
 
-	public function buildHeatLaterBlock(heatLaterBlock:Array<Expr>):Void {
-		heatLaterBlock.push(macro @:pos(this.nativePos) { null; });
+	public function buildHeatLaterDepsBlock(heatLaterDepsBlock:Array<Expr>):Void {
 	}
 
-	public function buildHeatUpBlock(heatUpBlock:Array<Expr>):Void {
-		heatUpBlock.push(macro @:pos(this.nativePos) { null; });
+	public function buildHeatUpNowBlock(heatUpNowBlock:Array<Expr>):Void {
 	}
 
-	public function buildHeatDownBlock(heatDownBlock:Array<Expr>):Void {
-		heatDownBlock.push(macro @:pos(this.nativePos) { null; });
+	public function buildHeatDownNowBlock(heatDownNowBlock:Array<Expr>):Void {
 	}
 
 	public function buildDisposeBlock(initBlock:Array<Expr>):Void {
-		initBlock.push(macro @:pos(this.nativePos) { null; });
 	}
 
 	public function buildConsumeSeedElementBlock(cases:MacroArpSwitchBlock):Void {

--- a/src/arp/macro/fields/std/MacroArpObjectStdMapField.hx
+++ b/src/arp/macro/fields/std/MacroArpObjectStdMapField.hx
@@ -42,18 +42,17 @@ class MacroArpObjectStdMapField extends MacroArpObjectCollectionFieldBase implem
 		_nativeType = coerce(super.nativeType);
 	}
 
-	public function buildHeatLaterBlock(heatLaterBlock:Array<Expr>):Void {
+	public function buildHeatLaterDepsBlock(heatLaterDepsBlock:Array<Expr>):Void {
 		if (!this.arpHasBarrier) return;
-		heatLaterBlock.push(macro @:pos(this.nativePos) { for (slot in this.$i_nativeName.slots) this._arpDomain.heatLater(slot, $v{arpBarrierRequired}); });
+		heatLaterDepsBlock.push(macro @:pos(this.nativePos) { for (slot in this.$i_nativeName.slots) this._arpDomain.heatLater(slot, $v{arpBarrierRequired}); });
 	}
 
-	public function buildHeatUpBlock(heatUpBlock:Array<Expr>):Void {
+	public function buildHeatUpNowBlock(heatUpNowBlock:Array<Expr>):Void {
 		if (!this.arpHasBarrier) return;
-		heatUpBlock.push(macro @:pos(this.nativePos) { if (this.$i_nativeName.heat != arp.domain.ArpHeat.Warm) return false; });
+		heatUpNowBlock.push(macro @:pos(this.nativePos) { if (this.$i_nativeName.heat != arp.domain.ArpHeat.Warm) return false; });
 	}
 
-	public function buildHeatDownBlock(heatDownBlock:Array<Expr>):Void {
-		heatDownBlock.push(macro @:pos(this.nativePos) { null; });
+	public function buildHeatDownNowBlock(heatDownNowBlock:Array<Expr>):Void {
 	}
 
 	public function buildDisposeBlock(disposeBlock:Array<Expr>):Void {

--- a/src/arp/macro/fields/std/MacroArpValueStdArrayField.hx
+++ b/src/arp/macro/fields/std/MacroArpValueStdArrayField.hx
@@ -20,20 +20,16 @@ class MacroArpValueStdArrayField extends MacroArpValueCollectionFieldBase implem
 		super(fieldDef, type, true);
 	}
 
-	public function buildHeatLaterBlock(heatLaterBlock:Array<Expr>):Void {
-		heatLaterBlock.push(macro @:pos(this.nativePos) { null; });
+	public function buildHeatLaterDepsBlock(heatLaterDepsBlock:Array<Expr>):Void {
 	}
 
-	public function buildHeatUpBlock(heatUpBlock:Array<Expr>):Void {
-		heatUpBlock.push(macro @:pos(this.nativePos) { null; });
+	public function buildHeatUpNowBlock(heatUpNowBlock:Array<Expr>):Void {
 	}
 
-	public function buildHeatDownBlock(heatDownBlock:Array<Expr>):Void {
-		heatDownBlock.push(macro @:pos(this.nativePos) { null; });
+	public function buildHeatDownNowBlock(heatDownNowBlock:Array<Expr>):Void {
 	}
 
 	public function buildDisposeBlock(initBlock:Array<Expr>):Void {
-		initBlock.push(macro @:pos(this.nativePos) { null; });
 	}
 
 	public function buildConsumeSeedElementBlock(cases:MacroArpSwitchBlock):Void {

--- a/src/arp/macro/fields/std/MacroArpValueStdListField.hx
+++ b/src/arp/macro/fields/std/MacroArpValueStdListField.hx
@@ -21,20 +21,16 @@ class MacroArpValueStdListField extends MacroArpValueCollectionFieldBase impleme
 		super(fieldDef, type, true);
 	}
 
-	public function buildHeatLaterBlock(heatLaterBlock:Array<Expr>):Void {
-		heatLaterBlock.push(macro @:pos(this.nativePos) { null; });
+	public function buildHeatLaterDepsBlock(heatLaterDepsBlock:Array<Expr>):Void {
 	}
 
-	public function buildHeatUpBlock(heatUpBlock:Array<Expr>):Void {
-		heatUpBlock.push(macro @:pos(this.nativePos) { null; });
+	public function buildHeatUpNowBlock(heatUpNowBlock:Array<Expr>):Void {
 	}
 
-	public function buildHeatDownBlock(heatDownBlock:Array<Expr>):Void {
-		heatDownBlock.push(macro @:pos(this.nativePos) { null; });
+	public function buildHeatDownNowBlock(heatDownNowBlock:Array<Expr>):Void {
 	}
 
 	public function buildDisposeBlock(initBlock:Array<Expr>):Void {
-		initBlock.push(macro @:pos(this.nativePos) { null; });
 	}
 
 	public function buildConsumeSeedElementBlock(cases:MacroArpSwitchBlock):Void {

--- a/src/arp/macro/fields/std/MacroArpValueStdMapField.hx
+++ b/src/arp/macro/fields/std/MacroArpValueStdMapField.hx
@@ -20,20 +20,16 @@ class MacroArpValueStdMapField extends MacroArpValueCollectionFieldBase implemen
 		super(fieldDef, type, concreteDs);
 	}
 
-	public function buildHeatLaterBlock(heatLaterBlock:Array<Expr>):Void {
-		heatLaterBlock.push(macro @:pos(this.nativePos) { null; });
+	public function buildHeatLaterDepsBlock(heatLaterDepsBlock:Array<Expr>):Void {
 	}
 
-	public function buildHeatUpBlock(heatUpBlock:Array<Expr>):Void {
-		heatUpBlock.push(macro @:pos(this.nativePos) { null; });
+	public function buildHeatUpNowBlock(heatUpNowBlock:Array<Expr>):Void {
 	}
 
-	public function buildHeatDownBlock(heatDownBlock:Array<Expr>):Void {
-		heatDownBlock.push(macro @:pos(this.nativePos) { null; });
+	public function buildHeatDownNowBlock(heatDownNowBlock:Array<Expr>):Void {
 	}
 
 	public function buildDisposeBlock(initBlock:Array<Expr>):Void {
-		initBlock.push(macro @:pos(this.nativePos) { null; } );
 	}
 
 	public function buildConsumeSeedElementBlock(cases:MacroArpSwitchBlock):Void {

--- a/src/arp/macro/stubs/MacroArpDerivedObjectStubs.hx
+++ b/src/arp/macro/stubs/MacroArpDerivedObjectStubs.hx
@@ -35,25 +35,25 @@ class MacroArpDerivedObjectStubs {
 		}
 	}
 
-	macro public static function arpHeatLater(heatLaterBlock:Expr):Expr {
+	macro public static function arpHeatLaterDeps(heatLaterDepsBlock:Expr):Expr {
 		@:macroReturn Bool;
 		return macro @:mergeBlock {
 			super.__arp_heatLaterDeps();
-			$e{ heatLaterBlock }
+			$e{ heatLaterDepsBlock }
 		}
 	}
 
-	macro public static function arpHeatUp(heatUpBlock:Expr):Expr {
+	macro public static function arpHeatUpNow(heatUpNowBlock:Expr):Expr {
 		return macro @:mergeBlock {
-			$e{ heatUpBlock }
+			$e{ heatUpNowBlock }
 			return super.__arp_heatUpNow();
 		}
 	}
 
-	macro public static function arpHeatDown(heatDownBlock:Expr):Expr {
+	macro public static function arpHeatDownNow(heatDownNowBlock:Expr):Expr {
 		@:macroReturn Bool;
 		return macro @:mergeBlock {
-			$e{ heatDownBlock }
+			$e{ heatDownNowBlock }
 			return super.__arp_heatDownNow();
 		}
 	}

--- a/src/arp/macro/stubs/MacroArpDerivedObjectStubs.hx
+++ b/src/arp/macro/stubs/MacroArpDerivedObjectStubs.hx
@@ -31,14 +31,14 @@ class MacroArpDerivedObjectStubs {
 
 		return macro @:mergeBlock {
 			$e{ initBlock }
-			return super.arpInit(slot, seed);
+			return super.__arp_init(slot, seed);
 		}
 	}
 
 	macro public static function arpHeatLater(heatLaterBlock:Expr):Expr {
 		@:macroReturn Bool;
 		return macro @:mergeBlock {
-			super.arpHeatLater();
+			super.__arp_heatLaterDeps();
 			$e{ heatLaterBlock }
 		}
 	}
@@ -46,22 +46,22 @@ class MacroArpDerivedObjectStubs {
 	macro public static function arpHeatUp(heatUpBlock:Expr):Expr {
 		return macro @:mergeBlock {
 			$e{ heatUpBlock }
-			return super.arpHeatUp();
+			return super.__arp_heatUpNow();
 		}
 	}
 
 	macro public static function arpHeatDown(heatDownBlock:Expr):Expr {
 		@:macroReturn Bool;
 		return macro @:mergeBlock {
-			// $e{ heatDownBlock }
-			return super.arpHeatDown();
+			$e{ heatDownBlock }
+			return super.__arp_heatDownNow();
 		}
 	}
 
 	macro public static function arpDispose(disposeBlock:Expr):Expr {
 		return macro @:mergeBlock {
 			$e{ disposeBlock }
-			super.arpDispose();
+			super.__arp_dispose();
 		}
 	}
 

--- a/src/arp/macro/stubs/MacroArpObjectSkeleton.hx
+++ b/src/arp/macro/stubs/MacroArpObjectSkeleton.hx
@@ -64,7 +64,7 @@ class MacroArpObjectSkeleton {
 			@:noDoc @:noCompletion private function get_arpHeat():arp.domain.ArpHeat return this._arpSlot.heat;
 
 			@:noDoc @:noCompletion
-			public function arpInit(slot:arp.domain.ArpUntypedSlot, seed:arp.seed.ArpSeed = null):arp.domain.IArpObject {
+			public function __arp_init(slot:arp.domain.ArpUntypedSlot, seed:arp.seed.ArpSeed = null):arp.domain.IArpObject {
 				arp.macro.stubs.MacroArpObjectStubs.arpInit(
 					$e{ this.buildInitBlock() },
 					$v{ this.classDef.hasImpl }
@@ -72,14 +72,14 @@ class MacroArpObjectSkeleton {
 			}
 
 			@:noDoc @:noCompletion
-			public function arpHeatLater():Void {
+			public function __arp_heatLaterDeps():Void {
 				arp.macro.stubs.MacroArpObjectStubs.arpHeatLater(
 					$e{ this.buildHeatLaterBlock() }
 				);
 			}
 
 			@:noDoc @:noCompletion
-			public function arpHeatUp():Bool {
+			public function __arp_heatUpNow():Bool {
 				arp.macro.stubs.MacroArpObjectStubs.arpHeatUp(
 					$e{ this.buildHeatUpBlock() },
 					$v{ this.classDef.hasImpl }
@@ -87,7 +87,7 @@ class MacroArpObjectSkeleton {
 			}
 
 			@:noDoc @:noCompletion
-			public function arpHeatDown():Bool {
+			public function __arp_heatDownNow():Bool {
 				arp.macro.stubs.MacroArpObjectStubs.arpHeatDown(
 					$e{ this.buildHeatDownBlock() },
 					$v{ this.classDef.hasImpl }
@@ -95,7 +95,7 @@ class MacroArpObjectSkeleton {
 			}
 
 			@:noDoc @:noCompletion
-			public function arpDispose():Void {
+			public function __arp_dispose():Void {
 				arp.macro.stubs.MacroArpObjectStubs.arpDispose(
 					$e{ this.buildDisposeBlock() },
 					$v{ this.classDef.hasImpl }
@@ -143,35 +143,35 @@ class MacroArpObjectSkeleton {
 			@:noDoc @:noCompletion override private function get_arpType():arp.domain.core.ArpType return _arpTypeInfo.arpType;
 
 			@:noDoc @:noCompletion
-			override public function arpInit(slot:arp.domain.ArpUntypedSlot, seed:arp.seed.ArpSeed = null):arp.domain.IArpObject {
+			override public function __arp_init(slot:arp.domain.ArpUntypedSlot, seed:arp.seed.ArpSeed = null):arp.domain.IArpObject {
 				arp.macro.stubs.MacroArpDerivedObjectStubs.arpInit(
 					$e{ this.buildInitBlock() }
 				);
 			}
 
 			@:noDoc @:noCompletion
-			override public function arpHeatLater():Void {
+			override public function __arp_heatLaterDeps():Void {
 				arp.macro.stubs.MacroArpDerivedObjectStubs.arpHeatLater(
 					$e{ this.buildHeatLaterBlock() }
 				);
 			}
 
 			@:noDoc @:noCompletion
-			override public function arpHeatUp():Bool {
+			override public function __arp_heatUpNow():Bool {
 				arp.macro.stubs.MacroArpDerivedObjectStubs.arpHeatUp(
 					$e{ this.buildHeatUpBlock() }
 				);
 			}
 
 			@:noDoc @:noCompletion
-			override public function arpHeatDown():Bool {
+			override public function __arp_heatDownNow():Bool {
 				arp.macro.stubs.MacroArpDerivedObjectStubs.arpHeatDown(
 					$e{ this.buildHeatDownBlock() }
 				);
 			}
 
 			@:noDoc @:noCompletion
-			override public function arpDispose():Void {
+			override public function __arp_dispose():Void {
 				arp.macro.stubs.MacroArpDerivedObjectStubs.arpDispose(
 					$e{ this.buildDisposeBlock() }
 				);

--- a/src/arp/macro/stubs/MacroArpObjectSkeleton.hx
+++ b/src/arp/macro/stubs/MacroArpObjectSkeleton.hx
@@ -30,9 +30,9 @@ class MacroArpObjectSkeleton {
 	}
 
 	private function buildInitBlock():Expr return buildBlock("buildInitBlock");
-	private function buildHeatLaterBlock():Expr return buildBlock("buildHeatLaterBlock");
-	private function buildHeatUpBlock():Expr return buildBlock("buildHeatUpBlock");
-	private function buildHeatDownBlock():Expr return buildBlock("buildHeatDownBlock");
+	private function buildHeatLaterDepsBlock():Expr return buildBlock("buildHeatLaterDepsBlock");
+	private function buildHeatUpNowBlock():Expr return buildBlock("buildHeatUpNowBlock");
+	private function buildHeatDownNowBlock():Expr return buildBlock("buildHeatDownNowBlock");
 	private function buildDisposeBlock():Expr return buildBlock("buildDisposeBlock");
 	private function buildReadSelfBlock():Expr return buildBlock("buildReadSelfBlock", true);
 	private function buildWriteSelfBlock():Expr return buildBlock("buildWriteSelfBlock", true);
@@ -73,23 +73,23 @@ class MacroArpObjectSkeleton {
 
 			@:noDoc @:noCompletion
 			public function __arp_heatLaterDeps():Void {
-				arp.macro.stubs.MacroArpObjectStubs.arpHeatLater(
-					$e{ this.buildHeatLaterBlock() }
+				arp.macro.stubs.MacroArpObjectStubs.arpHeatLaterDeps(
+					$e{ this.buildHeatLaterDepsBlock() }
 				);
 			}
 
 			@:noDoc @:noCompletion
 			public function __arp_heatUpNow():Bool {
-				arp.macro.stubs.MacroArpObjectStubs.arpHeatUp(
-					$e{ this.buildHeatUpBlock() },
+				arp.macro.stubs.MacroArpObjectStubs.arpHeatUpNow(
+					$e{ this.buildHeatUpNowBlock() },
 					$v{ this.classDef.hasImpl }
 				);
 			}
 
 			@:noDoc @:noCompletion
 			public function __arp_heatDownNow():Bool {
-				arp.macro.stubs.MacroArpObjectStubs.arpHeatDown(
-					$e{ this.buildHeatDownBlock() },
+				arp.macro.stubs.MacroArpObjectStubs.arpHeatDownNow(
+					$e{ this.buildHeatDownNowBlock() },
 					$v{ this.classDef.hasImpl }
 				);
 			}
@@ -151,22 +151,22 @@ class MacroArpObjectSkeleton {
 
 			@:noDoc @:noCompletion
 			override public function __arp_heatLaterDeps():Void {
-				arp.macro.stubs.MacroArpDerivedObjectStubs.arpHeatLater(
-					$e{ this.buildHeatLaterBlock() }
+				arp.macro.stubs.MacroArpDerivedObjectStubs.arpHeatLaterDeps(
+					$e{ this.buildHeatLaterDepsBlock() }
 				);
 			}
 
 			@:noDoc @:noCompletion
 			override public function __arp_heatUpNow():Bool {
-				arp.macro.stubs.MacroArpDerivedObjectStubs.arpHeatUp(
-					$e{ this.buildHeatUpBlock() }
+				arp.macro.stubs.MacroArpDerivedObjectStubs.arpHeatUpNow(
+					$e{ this.buildHeatUpNowBlock() }
 				);
 			}
 
 			@:noDoc @:noCompletion
 			override public function __arp_heatDownNow():Bool {
-				arp.macro.stubs.MacroArpDerivedObjectStubs.arpHeatDown(
-					$e{ this.buildHeatDownBlock() }
+				arp.macro.stubs.MacroArpDerivedObjectStubs.arpHeatDownNow(
+					$e{ this.buildHeatDownNowBlock() }
 				);
 			}
 

--- a/src/arp/macro/stubs/MacroArpObjectStubs.hx
+++ b/src/arp/macro/stubs/MacroArpObjectStubs.hx
@@ -75,7 +75,7 @@ class MacroArpObjectStubs {
 				if (hasImpl) {
 					macro {
 						if (this.arpImpl == null) throw new arp.errors.ArpTemplateError($v{"@:arpImpl could not find backend for "} + Type.getClassName(Type.getClass(this)));
-						if (!this.arpImpl.arpHeatUp()) isSync = false;
+						if (!this.arpImpl.__arp_heatUpNow()) isSync = false;
 					}
 				} else {
 					macro null;
@@ -100,7 +100,7 @@ class MacroArpObjectStubs {
 			var isSync:Bool = true;
 			$e{
 				if (hasImpl) {
-					macro if (!this.arpImpl.arpHeatDown()) isSync = false;
+					macro if (!this.arpImpl.__arp_heatDownNow()) isSync = false;
 				} else {
 					macro null;
 				}
@@ -116,10 +116,10 @@ class MacroArpObjectStubs {
 #if arp_debug
 			if (this._arpSlot == null) throw new arp.errors.ArpError("ArpObject is not initialized");
 #end
-			this.arpHeatDown();
+			this.__arp_heatDownNow();
 			$e{
 				if (hasImpl) {
-					macro this.arpImpl.arpDispose();
+					macro this.arpImpl.__arp_dispose();
 				} else {
 					macro null;
 				}

--- a/src/arp/macro/stubs/MacroArpObjectStubs.hx
+++ b/src/arp/macro/stubs/MacroArpObjectStubs.hx
@@ -52,23 +52,23 @@ class MacroArpObjectStubs {
 		}
 	}
 
-	macro public static function arpHeatLater(heatLaterBlock:Expr):Expr {
+	macro public static function arpHeatLaterDeps(heatLaterDepsBlock:Expr):Expr {
 		@:macroReturn Bool;
 		return macro @:mergeBlock {
 #if arp_debug
 			if (this._arpSlot == null) throw new arp.errors.ArpError("ArpObject is not initialized");
 #end
-			$e{ heatLaterBlock }
+			$e{ heatLaterDepsBlock }
 		}
 	}
 
-	macro public static function arpHeatUp(heatUpBlock:Expr, hasImpl:Bool):Expr {
+	macro public static function arpHeatUpNow(heatUpNowBlock:Expr, hasImpl:Bool):Expr {
 		@:macroReturn Bool;
 		return macro @:mergeBlock {
 #if arp_debug
 			if (this._arpSlot == null) throw new arp.errors.ArpError("ArpObject is not initialized");
 #end
-			$e{ heatUpBlock }
+			$e{ heatUpNowBlock }
 			var isSync:Bool = true;
 			if (!this.arpSelfHeatUp()) isSync = false;
 			$e{
@@ -91,7 +91,7 @@ class MacroArpObjectStubs {
 		}
 	}
 
-	macro public static function arpHeatDown(heatDownBlock:Expr, hasImpl:Bool):Expr {
+	macro public static function arpHeatDownNow(heatDownNowBlock:Expr, hasImpl:Bool):Expr {
 		@:macroReturn Bool;
 		return macro @:mergeBlock {
 #if arp_debug
@@ -106,7 +106,7 @@ class MacroArpObjectStubs {
 				}
 			}
 			if (!this.arpSelfHeatDown()) isSync = false;
-			// $e{ heatDownBlock }
+			$e{ heatDownNowBlock }
 			return isSync;
 		}
 	}

--- a/src/arp/seed/SeedObject.hx
+++ b/src/arp/seed/SeedObject.hx
@@ -41,7 +41,7 @@ class SeedObject implements IArpObject {
 	public var arpHeat(get, never):ArpHeat;
 	inline private function get_arpHeat():ArpHeat return this._arpSlot.heat;
 
-	public function arpInit(slot:ArpUntypedSlot, seed:ArpSeed = null):IArpObject {
+	public function __arp_init(slot:ArpUntypedSlot, seed:ArpSeed = null):IArpObject {
 		this._arpDomain = slot.domain;
 		this._arpSlot = slot;
 		if (seed != null) {
@@ -50,18 +50,18 @@ class SeedObject implements IArpObject {
 		return this;
 	}
 
-	public function arpHeatLater():Void {
+	public function __arp_heatLaterDeps():Void {
 	}
 
-	public function arpHeatUp():Bool {
+	public function __arp_heatUpNow():Bool {
 		return true;
 	}
 
-	public function arpHeatDown():Bool {
+	public function __arp_heatDownNow():Bool {
 		return true;
 	}
 
-	public function arpDispose():Void {
+	public function __arp_dispose():Void {
 		this._arpSlot = null;
 		this._arpDomain = null;
 	}

--- a/tests/arp/macro/EarlyPrepareMacroArpObjectCase.hx
+++ b/tests/arp/macro/EarlyPrepareMacroArpObjectCase.hx
@@ -48,12 +48,12 @@ class EarlyPrepareMacroArpObjectCase {
 		assertEquals(0, arpObj.volatileInt);
 		assertEquals(ArpHeat.Cold, arpObj.arpHeat);
 
-		arpObj.arpHeatUp();
+		arpObj.__arp_tryHeatUp();
 		assertFalse(domain.isPending);
 		assertEquals(1, arpObj.volatileInt);
 		assertEquals(ArpHeat.Warm, arpObj.arpHeat);
 
-		arpObj.arpDispose();
+		arpObj.__arp_dispose();
 		assertFalse(domain.isPending);
 		assertEquals(0, arpObj.volatileInt);
 		assertNull(arpObj._arpSlot);

--- a/tests/arp/macro/LatePrepareMacroArpObjectCase.hx
+++ b/tests/arp/macro/LatePrepareMacroArpObjectCase.hx
@@ -76,7 +76,7 @@ class LatePrepareMacroArpObjectCase {
 			assertEquals(1, arpObj.volatileInt);
 			assertEquals(ArpHeat.Warm, arpObj.arpHeat);
 
-			arpObj.arpDispose();
+			arpObj.__arp_dispose();
 			assertFalse(domain.isPending);
 			assertEquals(0, arpObj.volatileInt);
 			assertNull(arpObj._arpSlot);

--- a/tests/arp/macro/MacroDerivedArpObjectCase.hx
+++ b/tests/arp/macro/MacroDerivedArpObjectCase.hx
@@ -27,7 +27,7 @@ class MacroDerivedArpObjectCase {
 	public function testBuildObject():Void {
 		slot = domain.dir("name1").getOrCreateSlot(new ArpType("mock"));
 		arpObj = new MockMacroDerivedArpObject();
-		arpObj.arpInit(slot, seed);
+		arpObj.__arp_init(slot, seed);
 
 		assertEquals(domain, arpObj.arpDomain);
 		assertEquals(new ArpType("mock"), arpObj.arpType);


### PR DESCRIPTION
Things like `IArpObject.arpHeatUp()` is not meant to be called from user code, so at least try to hide them

Note: turning `IArpObject` into a class does not work, because Haxe private is Java protected