### PR TITLE
Early heatup API

### DIFF
--- a/src/arp/data/DataGroup.hx
+++ b/src/arp/data/DataGroup.hx
@@ -63,11 +63,11 @@ class DataGroup implements IArpObject {
 		for (slot in this.children) this.arpDomain.heatLater(slot);
 	}
 
-	public function __arp_heatUpNow():Bool {
+	public function arpHeatUpNow():Bool {
 		return true;
 	}
 
-	public function __arp_heatDownNow():Bool {
+	public function arpHeatDownNow():Bool {
 		return true;
 	}
 

--- a/src/arp/data/DataGroup.hx
+++ b/src/arp/data/DataGroup.hx
@@ -71,6 +71,8 @@ class DataGroup implements IArpObject {
 		return true;
 	}
 
+	inline public function arpHeatLater(nonblocking:Bool):Bool return this._arpDomain.heatLater(this._arpSlot, nonblocking);
+
 	public function __arp_dispose():Void {
 		for (slot in this.children) slot.delReference();
 		this._arpSlot = null;

--- a/src/arp/domain/ArpDomain.hx
+++ b/src/arp/domain/ArpDomain.hx
@@ -215,9 +215,12 @@ class ArpDomain {
 		this._onLog.dispatch(new ArpLogEvent(category, message));
 	}
 
-	public function heatLater(slot:ArpUntypedSlot, nonblocking:Bool = false):Void {
-		if (slot.heat != ArpHeat.Cold) return;
-		this.prepareQueue.prepareLater(slot, nonblocking);
+	public function heatLater(slot:ArpUntypedSlot, nonblocking:Bool = false):Bool {
+		switch (slot.heat) {
+			case ArpHeat.Warm: return true;
+			case ArpHeat.Warming: return false;
+			case ArpHeat.Cold: this.prepareQueue.prepareLater(slot, nonblocking); return false;
+		}
 	}
 
 	public function heatDown(slot:ArpUntypedSlot):Void {

--- a/src/arp/domain/ArpDomain.hx
+++ b/src/arp/domain/ArpDomain.hx
@@ -222,7 +222,6 @@ class ArpDomain {
 
 	public function heatDown(slot:ArpUntypedSlot):Void {
 		slot.value.__arp_heatDownNow();
-		@:privateAccess slot.heat = ArpHeat.Cold;
 	}
 
 	public function heatUpkeep():Void ArpHeatUpkeepScanner.execute(this);

--- a/src/arp/domain/ArpDomain.hx
+++ b/src/arp/domain/ArpDomain.hx
@@ -224,7 +224,7 @@ class ArpDomain {
 	}
 
 	public function heatDown(slot:ArpUntypedSlot):Void {
-		slot.value.__arp_heatDownNow();
+		slot.value.arpHeatDownNow();
 	}
 
 	public function heatUpkeep():Void ArpHeatUpkeepScanner.execute(this);

--- a/src/arp/domain/ArpDomain.hx
+++ b/src/arp/domain/ArpDomain.hx
@@ -221,7 +221,7 @@ class ArpDomain {
 
 	public function heatDown(slot:ArpUntypedSlot):Void {
 		slot.value.__arp_heatDownNow();
-		slot.heat = ArpHeat.Cold;
+		@:privateAccess slot.heat = ArpHeat.Cold;
 	}
 
 	public function heatUpkeep():Void ArpHeatUpkeepScanner.execute(this);

--- a/src/arp/domain/ArpDomain.hx
+++ b/src/arp/domain/ArpDomain.hx
@@ -223,11 +223,13 @@ class ArpDomain {
 		}
 	}
 
-	public function heatDown(slot:ArpUntypedSlot):Void {
-		slot.value.arpHeatDownNow();
-	}
+	inline public function heatUpNow(slot:ArpUntypedSlot):Bool return slot.value.arpHeatUpNow();
+	inline public function heatDownNow(slot:ArpUntypedSlot):Bool return slot.value.arpHeatDownNow();
 
-	public function heatUpkeep():Void ArpHeatUpkeepScanner.execute(this);
+	@:deprecated("heatDown() is renamed to heatDownNow()")
+	inline public function heatDown(slot:ArpUntypedSlot):Void slot.value.arpHeatDownNow();
+
+	inline public function heatUpkeep():Void ArpHeatUpkeepScanner.execute(this);
 
 	public var isPending(get, never):Bool;
 	inline public function get_isPending():Bool return this.prepareQueue.isPending;

--- a/src/arp/domain/ArpDomain.hx
+++ b/src/arp/domain/ArpDomain.hx
@@ -216,6 +216,7 @@ class ArpDomain {
 	}
 
 	public function heatLater(slot:ArpUntypedSlot, nonblocking:Bool = false):Void {
+		if (slot.heat != ArpHeat.Cold) return;
 		this.prepareQueue.prepareLater(slot, nonblocking);
 	}
 

--- a/src/arp/domain/ArpSlot.hx
+++ b/src/arp/domain/ArpSlot.hx
@@ -33,6 +33,10 @@ abstract ArpSlot<T:IArpObject>(ArpUntypedSlot) from ArpUntypedSlot to ArpUntyped
 	public var heat(get, never):ArpHeat;
 	inline private function get_heat():ArpHeat return this.heat;
 
+	inline public function heatUpNow():Bool return this.heatUpNow();
+	inline public function heatDownNow():Bool return this.heatDownNow();
+	inline public function heatLater(nonblocking:Bool = false):Bool return this.heatLater(nonblocking);
+
 	inline public function toString():String return this.toString();
 	inline public function describe():String return this.describe();
 

--- a/src/arp/domain/ArpSlot.hx
+++ b/src/arp/domain/ArpSlot.hx
@@ -30,10 +30,8 @@ abstract ArpSlot<T:IArpObject>(ArpUntypedSlot) from ArpUntypedSlot to ArpUntyped
 	inline public function takeReference(from:ArpSlot<T>):ArpSlot<T> return this.takeReference(from);
 	inline public function eternalReference():ArpSlot<T> return this.eternalReference();
 
-	// FIXME make setter friend access
-	public var heat(get, set):ArpHeat;
+	public var heat(get, never):ArpHeat;
 	inline private function get_heat():ArpHeat return this.heat;
-	inline private function set_heat(value:ArpHeat):ArpHeat return this.heat = value;
 
 	inline public function toString():String return this.toString();
 	inline public function describe():String return this.describe();

--- a/src/arp/domain/ArpUntypedSlot.hx
+++ b/src/arp/domain/ArpUntypedSlot.hx
@@ -52,6 +52,10 @@ class ArpUntypedSlot {
 
 	public var heat(default, null):ArpHeat = ArpHeat.Cold;
 
+	inline public function heatUpNow():Bool return this._value.__arp_heatUpNow();
+	inline public function heatDownNow():Bool return this._value.__arp_heatDownNow();
+	inline public function heatLater(nonblocking:Bool = false):Bool return this._domain.heatLater(this, nonblocking);
+
 	@:allow(arp.domain.ArpDomain.allocSlot)
 	private function new(domain:ArpDomain, sid:ArpSid, dir:ArpDirectory = null) {
 		this.domain = domain;

--- a/src/arp/domain/ArpUntypedSlot.hx
+++ b/src/arp/domain/ArpUntypedSlot.hx
@@ -50,10 +50,7 @@ class ArpUntypedSlot {
 
 	inline public function eternalReference():ArpUntypedSlot return this.addReference();
 
-	private var _heat:ArpHeat = ArpHeat.Cold;
-	public var heat(get, set):ArpHeat;
-	inline private function get_heat():ArpHeat { return this._heat; }
-	inline private function set_heat(value:ArpHeat):ArpHeat { return this._heat = value; }
+	public var heat(default, null):ArpHeat = ArpHeat.Cold;
 
 	@:allow(arp.domain.ArpDomain.allocSlot)
 	private function new(domain:ArpDomain, sid:ArpSid, dir:ArpDirectory = null) {

--- a/src/arp/domain/ArpUntypedSlot.hx
+++ b/src/arp/domain/ArpUntypedSlot.hx
@@ -52,8 +52,8 @@ class ArpUntypedSlot {
 
 	public var heat(default, null):ArpHeat = ArpHeat.Cold;
 
-	inline public function heatUpNow():Bool return this._value.__arp_heatUpNow();
-	inline public function heatDownNow():Bool return this._value.__arp_heatDownNow();
+	inline public function heatUpNow():Bool return this._value.arpHeatUpNow();
+	inline public function heatDownNow():Bool return this._value.arpHeatDownNow();
 	inline public function heatLater(nonblocking:Bool = false):Bool return this._domain.heatLater(this, nonblocking);
 
 	@:allow(arp.domain.ArpDomain.allocSlot)

--- a/src/arp/domain/IArpObject.hx
+++ b/src/arp/domain/IArpObject.hx
@@ -21,6 +21,7 @@ interface IArpObject extends IPersistable /* extends IArpObjectImpl */ {
 
 	function arpHeatUpNow():Bool;
 	function arpHeatDownNow():Bool;
+	function arpHeatLater(nonblocking:Bool):Bool;
 
 	@:noDoc @:noCompletion function __arp_init(slot:ArpUntypedSlot, seed:ArpSeed = null):IArpObject;
 	@:noDoc @:noCompletion function __arp_dispose():Void;

--- a/src/arp/domain/IArpObject.hx
+++ b/src/arp/domain/IArpObject.hx
@@ -16,12 +16,13 @@ interface IArpObject extends IPersistable /* extends IArpObjectImpl */ {
 	var arpSlot(get, never):ArpUntypedSlot;
 	var arpHeat(get, never):ArpHeat;
 
-	@:noDoc @:noCompletion function __arp_init(slot:ArpUntypedSlot, seed:ArpSeed = null):IArpObject;
-	@:noDoc @:noCompletion function __arp_dispose():Void;
 	function arpClone():IArpObject;
 	function arpCopyFrom(source:IArpObject):IArpObject;
 
+	function arpHeatUpNow():Bool;
+	function arpHeatDownNow():Bool;
+
+	@:noDoc @:noCompletion function __arp_init(slot:ArpUntypedSlot, seed:ArpSeed = null):IArpObject;
+	@:noDoc @:noCompletion function __arp_dispose():Void;
 	@:noDoc @:noCompletion function __arp_heatLaterDeps():Void;
-	@:noDoc @:noCompletion function __arp_heatUpNow():Bool;
-	@:noDoc @:noCompletion function __arp_heatDownNow():Bool;
 }

--- a/src/arp/domain/prepare/ArpHeatUpkeepScanner.hx
+++ b/src/arp/domain/prepare/ArpHeatUpkeepScanner.hx
@@ -37,7 +37,7 @@ private class ArpHeatUpkeepVisitor implements IArpDomainDirectoryVisitor<Bool> {
 			case ArpHeat.Warming | ArpHeat.Warm:
 				var value:IArpObject = slot.value;
 				if (value.__arp_heatUpNow()) return;
-				value.arpDomain.heatLater(slot, false);
+				@:privateAccess value.arpDomain.prepareQueue.prepareLater(slot, false);
 				isPending = true;
 			case _:
 		}

--- a/src/arp/domain/prepare/ArpHeatUpkeepScanner.hx
+++ b/src/arp/domain/prepare/ArpHeatUpkeepScanner.hx
@@ -36,7 +36,7 @@ private class ArpHeatUpkeepVisitor implements IArpDomainDirectoryVisitor<Bool> {
 		switch (slot.heat) {
 			case ArpHeat.Warming | ArpHeat.Warm:
 				var value:IArpObject = slot.value;
-				if (value.__arp_heatUpNow()) return;
+				if (value.arpHeatUpNow()) return;
 				@:privateAccess value.arpDomain.prepareQueue.prepareLater(slot, false);
 				isPending = true;
 			case _:

--- a/src/arp/domain/prepare/PrepareQueue.hx
+++ b/src/arp/domain/prepare/PrepareQueue.hx
@@ -87,7 +87,7 @@ class PrepareQueue implements IPrepareStatus {
 	}
 
 	private function onCompleteTask(task:PrepareTask):Void {
-		task.slot.heat = ArpHeat.Warm;
+		@:privateAccess task.slot.heat = ArpHeat.Warm;
 		this.tasksBySlots.remove(task.slot);
 		if (!task.nonblocking) this.tasksBlocking--;
 	}
@@ -102,7 +102,7 @@ class PrepareQueue implements IPrepareStatus {
 		this.tasksBySlots.set(slot, task);
 		if (!nonblocking) this.tasksBlocking++;
 		this.taskRunner.append(task);
-		task.slot.heat = ArpHeat.Warming;
+		@:privateAccess task.slot.heat = ArpHeat.Warming;
 		this.domain.log("arp_debug_prepare", 'PrepareQueue.prepareLater(): prepare later ${slot} ${if (nonblocking) "(nonblocking)" else ""}');
 	}
 

--- a/src/arp/domain/prepare/PrepareTask.hx
+++ b/src/arp/domain/prepare/PrepareTask.hx
@@ -40,7 +40,7 @@ class PrepareTask implements ITask {
 		}
 
 		// try to heat up myself
-		if (!this.slot.value.__arp_heatUpNow()) {
+		if (!this.slot.value.arpHeatUpNow()) {
 			this.domain.log("arp_debug_prepare", 'PrepareTask.run(): waiting depending prepares: ${this.slot}');
 			return TaskStatus.Stalled;
 		}

--- a/src/arp/impl/IArpObjectImpl.hx
+++ b/src/arp/impl/IArpObjectImpl.hx
@@ -1,7 +1,8 @@
 package arp.impl;
 
 interface IArpObjectImpl {
-	@:noDoc @:noCompletion function __arp_heatUpNow():Bool;
-	@:noDoc @:noCompletion function __arp_heatDownNow():Bool;
+	function arpHeatUpNow():Bool;
+	function arpHeatDownNow():Bool;
+
 	@:noDoc @:noCompletion function __arp_dispose():Void;
 }

--- a/src/arp/macro/stubs/MacroArpDerivedObjectStubs.hx
+++ b/src/arp/macro/stubs/MacroArpDerivedObjectStubs.hx
@@ -46,7 +46,7 @@ class MacroArpDerivedObjectStubs {
 	macro public static function arpHeatUpNow(heatUpNowBlock:Expr):Expr {
 		return macro @:mergeBlock {
 			$e{ heatUpNowBlock }
-			return super.__arp_heatUpNow();
+			return super.arpHeatUpNow();
 		}
 	}
 
@@ -54,7 +54,7 @@ class MacroArpDerivedObjectStubs {
 		@:macroReturn Bool;
 		return macro @:mergeBlock {
 			$e{ heatDownNowBlock }
-			return super.__arp_heatDownNow();
+			return super.arpHeatDownNow();
 		}
 	}
 

--- a/src/arp/macro/stubs/MacroArpObjectSkeleton.hx
+++ b/src/arp/macro/stubs/MacroArpObjectSkeleton.hx
@@ -79,7 +79,7 @@ class MacroArpObjectSkeleton {
 			}
 
 			@:noDoc @:noCompletion
-			public function __arp_heatUpNow():Bool {
+			public function arpHeatUpNow():Bool {
 				arp.macro.stubs.MacroArpObjectStubs.arpHeatUpNow(
 					$e{ this.buildHeatUpNowBlock() },
 					$v{ this.classDef.hasImpl }
@@ -87,7 +87,7 @@ class MacroArpObjectSkeleton {
 			}
 
 			@:noDoc @:noCompletion
-			public function __arp_heatDownNow():Bool {
+			public function arpHeatDownNow():Bool {
 				arp.macro.stubs.MacroArpObjectStubs.arpHeatDownNow(
 					$e{ this.buildHeatDownNowBlock() },
 					$v{ this.classDef.hasImpl }
@@ -157,14 +157,14 @@ class MacroArpObjectSkeleton {
 			}
 
 			@:noDoc @:noCompletion
-			override public function __arp_heatUpNow():Bool {
+			override public function arpHeatUpNow():Bool {
 				arp.macro.stubs.MacroArpDerivedObjectStubs.arpHeatUpNow(
 					$e{ this.buildHeatUpNowBlock() }
 				);
 			}
 
 			@:noDoc @:noCompletion
-			override public function __arp_heatDownNow():Bool {
+			override public function arpHeatDownNow():Bool {
 				arp.macro.stubs.MacroArpDerivedObjectStubs.arpHeatDownNow(
 					$e{ this.buildHeatDownNowBlock() }
 				);

--- a/src/arp/macro/stubs/MacroArpObjectSkeleton.hx
+++ b/src/arp/macro/stubs/MacroArpObjectSkeleton.hx
@@ -78,7 +78,6 @@ class MacroArpObjectSkeleton {
 				);
 			}
 
-			@:noDoc @:noCompletion
 			public function arpHeatUpNow():Bool {
 				arp.macro.stubs.MacroArpObjectStubs.arpHeatUpNow(
 					$e{ this.buildHeatUpNowBlock() },
@@ -86,13 +85,14 @@ class MacroArpObjectSkeleton {
 				);
 			}
 
-			@:noDoc @:noCompletion
 			public function arpHeatDownNow():Bool {
 				arp.macro.stubs.MacroArpObjectStubs.arpHeatDownNow(
 					$e{ this.buildHeatDownNowBlock() },
 					$v{ this.classDef.hasImpl }
 				);
 			}
+
+			inline public function arpHeatLater(nonblocking:Bool):Bool return this._arpDomain.heatLater(this._arpSlot, nonblocking);
 
 			@:noDoc @:noCompletion
 			public function __arp_dispose():Void {
@@ -156,14 +156,12 @@ class MacroArpObjectSkeleton {
 				);
 			}
 
-			@:noDoc @:noCompletion
 			override public function arpHeatUpNow():Bool {
 				arp.macro.stubs.MacroArpDerivedObjectStubs.arpHeatUpNow(
 					$e{ this.buildHeatUpNowBlock() }
 				);
 			}
 
-			@:noDoc @:noCompletion
 			override public function arpHeatDownNow():Bool {
 				arp.macro.stubs.MacroArpDerivedObjectStubs.arpHeatDownNow(
 					$e{ this.buildHeatDownNowBlock() }

--- a/src/arp/macro/stubs/MacroArpObjectStubs.hx
+++ b/src/arp/macro/stubs/MacroArpObjectStubs.hx
@@ -107,6 +107,7 @@ class MacroArpObjectStubs {
 			}
 			if (!this.arpSelfHeatDown()) isSync = false;
 			$e{ heatDownNowBlock }
+			@:privateAccess this.arpSlot.heat = arp.domain.ArpHeat.Cold;
 			return isSync;
 		}
 	}

--- a/src/arp/macro/stubs/MacroArpObjectStubs.hx
+++ b/src/arp/macro/stubs/MacroArpObjectStubs.hx
@@ -82,10 +82,10 @@ class MacroArpObjectStubs {
 				}
 			}
 			if (isSync) {
-				this.arpSlot.heat = arp.domain.ArpHeat.Warm;
+				@:privateAccess this.arpSlot.heat = arp.domain.ArpHeat.Warm;
 				return true;
 			} else {
-				this.arpSlot.heat = arp.domain.ArpHeat.Warming;
+				@:privateAccess this.arpSlot.heat = arp.domain.ArpHeat.Warming;
 				return false;
 			}
 		}

--- a/src/arp/macro/stubs/MacroArpObjectStubs.hx
+++ b/src/arp/macro/stubs/MacroArpObjectStubs.hx
@@ -75,7 +75,7 @@ class MacroArpObjectStubs {
 				if (hasImpl) {
 					macro {
 						if (this.arpImpl == null) throw new arp.errors.ArpTemplateError($v{"@:arpImpl could not find backend for "} + Type.getClassName(Type.getClass(this)));
-						if (!this.arpImpl.__arp_heatUpNow()) isSync = false;
+						if (!this.arpImpl.arpHeatUpNow()) isSync = false;
 					}
 				} else {
 					macro null;
@@ -100,7 +100,7 @@ class MacroArpObjectStubs {
 			var isSync:Bool = true;
 			$e{
 				if (hasImpl) {
-					macro if (!this.arpImpl.__arp_heatDownNow()) isSync = false;
+					macro if (!this.arpImpl.arpHeatDownNow()) isSync = false;
 				} else {
 					macro null;
 				}
@@ -117,7 +117,7 @@ class MacroArpObjectStubs {
 #if arp_debug
 			if (this._arpSlot == null) throw new arp.errors.ArpError("ArpObject is not initialized");
 #end
-			this.__arp_heatDownNow();
+			this.arpHeatDownNow();
 			$e{
 				if (hasImpl) {
 					macro this.arpImpl.__arp_dispose();

--- a/src/arp/seed/SeedObject.hx
+++ b/src/arp/seed/SeedObject.hx
@@ -53,11 +53,11 @@ class SeedObject implements IArpObject {
 	public function __arp_heatLaterDeps():Void {
 	}
 
-	public function __arp_heatUpNow():Bool {
+	public function arpHeatUpNow():Bool {
 		return true;
 	}
 
-	public function __arp_heatDownNow():Bool {
+	public function arpHeatDownNow():Bool {
 		return true;
 	}
 

--- a/src/arp/seed/SeedObject.hx
+++ b/src/arp/seed/SeedObject.hx
@@ -61,6 +61,8 @@ class SeedObject implements IArpObject {
 		return true;
 	}
 
+	inline public function arpHeatLater(nonblocking:Bool):Bool return this._arpDomain.heatLater(this._arpSlot, nonblocking);
+
 	public function __arp_dispose():Void {
 		this._arpSlot = null;
 		this._arpDomain = null;

--- a/tests/arp/domain/mocks/MockArpObject.hx
+++ b/tests/arp/domain/mocks/MockArpObject.hx
@@ -74,6 +74,8 @@ class MockArpObject implements IArpObject {
 		return true;
 	}
 
+	inline public function arpHeatLater(nonblocking:Bool):Bool return this._arpDomain.heatLater(this._arpSlot, nonblocking);
+
 	public function __arp_dispose():Void {
 		this.dispose();
 		this._arpSlot = null;

--- a/tests/arp/domain/mocks/MockArpObject.hx
+++ b/tests/arp/domain/mocks/MockArpObject.hx
@@ -58,7 +58,7 @@ class MockArpObject implements IArpObject {
 		this._arpDomain.heatLater(this.refFieldSlot);
 	}
 
-	public function __arp_heatUpNow():Bool {
+	public function arpHeatUpNow():Bool {
 		return this.heatUp();
 	}
 
@@ -66,7 +66,7 @@ class MockArpObject implements IArpObject {
 		return true;
 	}
 
-	public function __arp_heatDownNow():Bool {
+	public function arpHeatDownNow():Bool {
 		return this.heatDown();
 	}
 

--- a/tests/arp/macro/EarlyPrepareMacroArpObjectCase.hx
+++ b/tests/arp/macro/EarlyPrepareMacroArpObjectCase.hx
@@ -48,7 +48,7 @@ class EarlyPrepareMacroArpObjectCase {
 		assertEquals(0, arpObj.volatileInt);
 		assertEquals(ArpHeat.Cold, arpObj.arpHeat);
 
-		arpObj.__arp_heatUpNow();
+		arpObj.arpHeatUpNow();
 		assertFalse(domain.isPending);
 		assertEquals(1, arpObj.volatileInt);
 		assertEquals(ArpHeat.Warm, arpObj.arpHeat);

--- a/tests/arp/macro/mocks/MockConcreteImplMacroArpObject.hx
+++ b/tests/arp/macro/mocks/MockConcreteImplMacroArpObject.hx
@@ -40,11 +40,11 @@ class MockConcreteImpl implements IMockConcreteImpl {
 		this.initialHeat = this.currentHeat;
 	}
 
-	public function __arp_heatUpNow():Bool {
+	public function arpHeatUpNow():Bool {
 		currentHeat = ArpHeat.Warm;
 		return true;
 	}
-	public function __arp_heatDownNow():Bool {
+	public function arpHeatDownNow():Bool {
 		currentHeat = ArpHeat.Cold;
 		return true;
 	}

--- a/tests/arp/macro/mocks/MockImplMacroArpObject.hx
+++ b/tests/arp/macro/mocks/MockImplMacroArpObject.hx
@@ -31,11 +31,11 @@ class MockImpl {
 		this.initialHeat = this.currentHeat;
 	}
 
-	public function __arp_heatUpNow():Bool {
+	public function arpHeatUpNow():Bool {
 		currentHeat = ArpHeat.Warm;
 		return true;
 	}
-	public function __arp_heatDownNow():Bool {
+	public function arpHeatDownNow():Bool {
 		currentHeat = ArpHeat.Cold;
 		return true;
 	}


### PR DESCRIPTION
Try to resolve #20

- [x] Change `IArpObject.__arp_heatUpNow()` public
- [x] Change `IArpObject.__arp_heatDownNow()` macro
- [x] Change `IArpObject.__arp_heatDownNow()` public
- [x] Add `IArpObject.arpHeatLater()` delegate
- [x] Add `ArpUntypedSlot.heatLater()` delegate
- [x] Add `ArpUntypedSlot.heatUpNow()` delegate
- [x] Add `ArpUntypedSlot.heatDownNow()` delegate
- [x] Hide `ArpUntypedSlot.heat` setter
- [x] `ArpDomain.heatLater()` should do nothing for `Warm` or `Warming` objects
- [x] Deprecate some heat related methods of `ArpDomain`
