### PR TITLE
Allow relative path with @:arpDefault

### DIFF
--- a/src/arp/macro/fields/MacroArpObjectField.hx
+++ b/src/arp/macro/fields/MacroArpObjectField.hx
@@ -51,7 +51,7 @@ class MacroArpObjectField extends MacroArpFieldBase implements IMacroArpField {
 				initBlock.push(macro @:pos(this.nativePos) { this.$iNativeSlot = slot.domain.nullSlot; });
 			case MacroArpMetaArpDefault.Simple(s):
 				// FIXME must allow relative path from this ArpObject
-				initBlock.push(macro @:pos(this.nativePos) { this.$iNativeSlot = slot.domain.query($v{s}, ${this.eArpType}).slot().addReference(); });
+				initBlock.push(macro @:pos(this.nativePos) { this.$iNativeSlot = slot.primaryDir.query($v{s}, ${this.eArpType}).slot().addReference(); });
 		}
 	}
 

--- a/src/arp/macro/fields/MacroArpObjectField.hx
+++ b/src/arp/macro/fields/MacroArpObjectField.hx
@@ -50,8 +50,8 @@ class MacroArpObjectField extends MacroArpFieldBase implements IMacroArpField {
 			case MacroArpMetaArpDefault.Zero:
 				initBlock.push(macro @:pos(this.nativePos) { this.$iNativeSlot = slot.domain.nullSlot; });
 			case MacroArpMetaArpDefault.Simple(s):
-				// FIXME must allow relative path from this ArpObject
-				initBlock.push(macro @:pos(this.nativePos) { this.$iNativeSlot = slot.primaryDir.query($v{s}, ${this.eArpType}).slot().addReference(); });
+				// FIXME oooo
+				initBlock.push(macro @:pos(this.nativePos) { this.$iNativeSlot = (if (slot.primaryDir != null) slot.primaryDir else slot.domain.root).query($v{s}, ${this.eArpType}).slot().addReference(); });
 		}
 	}
 

--- a/tests/arp/macro/mocks/MockDefaultMacroArpObject.hx
+++ b/tests/arp/macro/mocks/MockDefaultMacroArpObject.hx
@@ -10,7 +10,7 @@ class MockDefaultMacroArpObject implements IArpObject {
 	@:arpField @:arpDefault("true") public var boolField:Bool = false;
 	@:arpField @:arpDefault("stringDefault3") public var stringField:String = null;
 
-	@:arpField @:arpDefault("name1") public var refField:MockDefaultMacroArpObject;
+	@:arpField @:arpDefault("/name1") public var refField:MockDefaultMacroArpObject;
 
 	public function new() {
 	}

--- a/tests/arp/macro/mocks/MockMacroArpObject.hx
+++ b/tests/arp/macro/mocks/MockMacroArpObject.hx
@@ -21,7 +21,7 @@ class MockMacroArpObject implements IArpObject {
 
 	@:arpBarrier @:arpField public var refField:MockMacroArpObject;
 
-	@:arpField @:arpDefault("name1") public var refField3:MockMacroArpObject;
+	@:arpField @:arpDefault("/name1") public var refField3:MockMacroArpObject;
 
 	public function new() {
 	}


### PR DESCRIPTION
This is actually about treating @:arpDefault as relative path NOT absolute path.