### PR TITLE
Introduce anonRoot

### DIFF
--- a/src/arp/domain/ArpDirectory.hx
+++ b/src/arp/domain/ArpDirectory.hx
@@ -40,6 +40,8 @@ class ArpDirectory {
 		return this;
 	}
 
+	inline public function eternalReference():ArpDirectory return this.addReference();
+
 	private function free():Void {
 		if (this.parent != null) {
 			this.parent.children.remove(this);

--- a/src/arp/domain/ArpDomain.hx
+++ b/src/arp/domain/ArpDomain.hx
@@ -32,6 +32,7 @@ import arp.macro.MacroArpObjectRegistry;
 class ArpDomain {
 
 	public var root(default, null):ArpDirectory;
+	private var anonRoot(default, null):ArpDirectory;
 
 	@:noDoc
 	public var currentDir(get, never):ArpDirectory;
@@ -73,6 +74,7 @@ class ArpDomain {
 		this._onLog = new ArpSignal<ArpLogEvent>();
 
 		this.root = new ArpDirectory(this, ArpDid.rootDir());
+		this.anonRoot = this.dir(ArpIdGenerator.AUTO_HEADER + "anon");
 		this.currentDirStack = [this.root];
 		this.slots = new Map();
 		this.nullSlot = this.allocSlot(ArpSid.nullSlot()).eternalReference();

--- a/src/arp/domain/ArpDomain.hx
+++ b/src/arp/domain/ArpDomain.hx
@@ -74,10 +74,10 @@ class ArpDomain {
 		this._onLog = new ArpSignal<ArpLogEvent>();
 
 		this.root = new ArpDirectory(this, ArpDid.rootDir());
-		this.anonRoot = this.dir(ArpIdGenerator.AUTO_HEADER + "anon");
+		this.anonRoot = this.dir(ArpIdGenerator.AUTO_HEADER + "anon").eternalReference();
 		this.currentDirStack = [this.root];
 		this.slots = new Map();
-		this.nullSlot = this.allocSlot(ArpSid.nullSlot()).eternalReference();
+		this.nullSlot = this.allocSlot(ArpSid.nullSlot(), this.root).eternalReference();
 		this.registry = new ArpObjectFactoryRegistry();
 		this.prepareQueue = new PrepareQueue(this, this._rawTick);
 
@@ -95,7 +95,7 @@ class ArpDomain {
 		}
 	}
 
-	inline private function allocSlot(sid:ArpSid, dir:ArpDirectory = null):ArpUntypedSlot {
+	inline private function allocSlot(sid:ArpSid, dir:ArpDirectory):ArpUntypedSlot {
 		var slot:ArpUntypedSlot = new ArpUntypedSlot(this, sid, dir);
 		this.slots.set(sid.toString(), slot);
 		return slot;
@@ -109,7 +109,7 @@ class ArpDomain {
 
 	inline private function createAnonymousSlot(arpType:ArpType):ArpUntypedSlot {
 		var sid = ArpSid.build(new ArpDid(_did.next()), arpType);
-		return this.allocSlot(sid, null);
+		return this.allocSlot(sid, this.anonRoot);
 	}
 
 	@:allow(arp.domain.ArpUntypedSlot.delReference)
@@ -124,7 +124,7 @@ class ArpDomain {
 	public function getOrCreateSlot<T:IArpObject>(sid:ArpSid):ArpSlot<T> {
 		var slot:ArpSlot<T> = this.slots.get(sid.toString());
 		if (slot != null) return slot;
-		return allocSlot(sid);
+		return allocSlot(sid, this.anonRoot);
 	}
 
 	inline public function dir(path:String = null):ArpDirectory {

--- a/src/arp/domain/ArpDomainPersist.hx
+++ b/src/arp/domain/ArpDomainPersist.hx
@@ -29,8 +29,8 @@ abstract ArpDomainPersist(ArpDomain) {
 				var arpType:String = input.nextUtf();
 				var arpSlot:ArpUntypedSlot = this.getOrCreateSlot(new ArpSid(input.nextUtf()));
 				@:privateAccess this.dir(dir).slots.set(arpType, arpSlot);
-				input.readExit();
 			}
+			input.readExit();
 			input.readExit();
 		}
 		input.readExit();

--- a/src/arp/domain/ArpUntypedSlot.hx
+++ b/src/arp/domain/ArpUntypedSlot.hx
@@ -38,7 +38,7 @@ class ArpUntypedSlot {
 				this._value = null;
 			}
 			this._domain.freeSlot(this);
-			if (this._primaryDir != null) this._primaryDir.delReference();
+			this._primaryDir.delReference();
 		}
 		return this;
 	}
@@ -57,11 +57,11 @@ class ArpUntypedSlot {
 	inline public function heatLater(nonblocking:Bool = false):Bool return this._domain.heatLater(this, nonblocking);
 
 	@:allow(arp.domain.ArpDomain.allocSlot)
-	private function new(domain:ArpDomain, sid:ArpSid, dir:ArpDirectory = null) {
+	private function new(domain:ArpDomain, sid:ArpSid, dir:ArpDirectory) {
 		this.domain = domain;
 		this.sid = sid;
 		this._primaryDir = dir;
-		if (dir != null) dir.addReference();
+		dir.addReference();
 	}
 
 	public function toString():String return '<$sid>';

--- a/src/arp/domain/prepare/PrepareQueue.hx
+++ b/src/arp/domain/prepare/PrepareQueue.hx
@@ -67,7 +67,7 @@ class PrepareQueue implements IPrepareStatus {
 			var slot:ArpUntypedSlot = kv.key;
 			var task:PrepareTask = kv.value;
 			message += '\n${task.waiting ? "*" : " "}[${Type.getClass(slot.value)}]${slot.sid}';
-			if (slot.primaryDir != null) message += ' @ ${slot.primaryDir.did}';
+			message += ' @ ${slot.primaryDir.did}';
 		}
 		this.onTaskRunnerError(message);
 	}

--- a/tests/arp/domain/ArpDomainCase.hx
+++ b/tests/arp/domain/ArpDomainCase.hx
@@ -41,6 +41,7 @@ class ArpDomainCase {
   }
 ';
 		var DUMP_BY_NAME:String = '% <<dir>>:  {
+%   $$anon: /$$anon
 %   name1: /name1 {
 -     <mock>: /name1:mock [2]
     }
@@ -99,6 +100,7 @@ class ArpDomainCase {
   }
 ';
 		var DUMP_BY_NAME:String = '% <<dir>>:  {
+%   $$anon: /$$anon
 %   name2: /name2 {
 -     <mock>: /name2:mock [2]
     }
@@ -123,6 +125,7 @@ class ArpDomainCase {
   }
 ';
 		var DUMP_BY_NAME:String = '% <<dir>>:  {
+%   $$anon: /$$anon
 %   name2: /name2 {
 -     <mock>: /name2:mock [2]
     }

--- a/tests/arp/domain/ArpDomainPersistCase.hx
+++ b/tests/arp/domain/ArpDomainPersistCase.hx
@@ -16,9 +16,15 @@ class ArpDomainPersistCase {
 	private var xml:Xml;
 	private var seed:ArpSeed;
 
-	private final PERSIST:Dynamic = untyped {
-		"numDirs": 3,
+	private final PERSIST_JSON:Dynamic = untyped {
+		"numDirs": 4,
 		"dirs": [
+			{
+				"numSlots": 0,
+				"path": '/$$anon',
+				"slots": [
+				]
+			},
 			{
 				"numSlots": 1,
 				"path": "/name1",
@@ -89,6 +95,86 @@ class ArpDomainPersistCase {
 		]
 	};
 
+	private final PERSIST_VERBOSE:Dynamic = untyped [
+		"   1:0 :writeInt32:numDirs:4",
+		"   2:0 :writeListEnter:dirs",
+		"   3:1   :pushEnter:",
+		"   4:2     :writeInt32:numSlots:0",
+		"   5:2     :writeUtf:path:%2F%24anon",
+		"   6:2     :writeListEnter:slots",
+		"   7:2     :writeExit:",
+		"   8:1   :writeExit:",
+		"   9:1   :pushEnter:",
+		"  10:2     :writeInt32:numSlots:1",
+		"  11:2     :writeUtf:path:%2Fname1",
+		"  12:2     :writeListEnter:slots",
+		"  13:3       :pushUtf:mock",
+		"  14:3       :pushUtf:%2Fname1%3Amock",
+		"  15:2     :writeExit:",
+		"  16:1   :writeExit:",
+		"  17:1   :pushEnter:",
+		"  18:2     :writeInt32:numSlots:1",
+		"  19:2     :writeUtf:path:%2Fname2",
+		"  20:2     :writeListEnter:slots",
+		"  21:3       :pushUtf:mock",
+		"  22:3       :pushUtf:%2Fname2%3Amock",
+		"  23:2     :writeExit:",
+		"  24:1   :writeExit:",
+		"  25:1   :pushEnter:",
+		"  26:2     :writeInt32:numSlots:1",
+		"  27:2     :writeUtf:path:%2Fname3",
+		"  28:2     :writeListEnter:slots",
+		"  29:3       :pushUtf:mock",
+		"  30:3       :pushUtf:%2Fname3%3Amock",
+		"  31:2     :writeExit:",
+		"  32:1   :writeExit:",
+		"  33:0 :writeExit:",
+		"  34:0 :writeInt32:numSlots:5",
+		"  35:0 :writeListEnter:slots",
+		"  36:1   :pushEnter:",
+		"  37:2     :writeUtf:class:mock%3Amock",
+		"  38:2     :writeUtf:heat:cold",
+		"  39:2     :writeUtf:name:%2Fname3%3Amock",
+		"  40:2     :writeInt32:intField:0",
+		"  41:2     :writeDouble:floatField:0",
+		"  42:2     :writeBool:boolField:false",
+		"  43:2     :writeUtf:stringField:stringDefault",
+		"  44:2     :writeUtf:refField:%24null",
+		"  45:1   :writeExit:",
+		"  46:1   :pushEnter:",
+		"  47:2     :writeUtf:class:data%3Adata",
+		"  48:2     :writeUtf:heat:cold",
+		"  49:2     :writeUtf:name:%240%3Adata",
+		"  50:1   :writeExit:",
+		"  51:1   :pushEnter:",
+		"  52:2     :writeUtf:class:mock%3Amock",
+		"  53:2     :writeUtf:heat:cold",
+		"  54:2     :writeUtf:name:%2Fname1%3Amock",
+		"  55:2     :writeInt32:intField:42",
+		"  56:2     :writeDouble:floatField:3.14",
+		"  57:2     :writeBool:boolField:true",
+		"  58:2     :writeUtf:stringField:stringValue",
+		"  59:2     :writeUtf:refField:%2Fname1%3Amock",
+		"  60:1   :writeExit:",
+		"  61:1   :pushEnter:",
+		"  62:2     :writeUtf:class:%24null",
+		"  63:2     :writeUtf:heat:cold",
+		"  64:2     :writeUtf:name:%24null",
+		"  65:1   :writeExit:",
+		"  66:1   :pushEnter:",
+		"  67:2     :writeUtf:class:mock%3Amock",
+		"  68:2     :writeUtf:heat:cold",
+		"  69:2     :writeUtf:name:%2Fname2%3Amock",
+		"  70:2     :writeInt32:intField:0",
+		"  71:2     :writeDouble:floatField:0",
+		"  72:2     :writeBool:boolField:false",
+		"  73:2     :writeUtf:stringField:stringDefault",
+		"  74:2     :writeUtf:refField:%2Fname1%3Amock",
+		"  75:1   :writeExit:",
+		"  76:0 :writeExit:"
+	]
+	;
+
 	public function setup():Void {
 		domain = new ArpDomain();
 		domain.addTemplate(MockArpObject, true);
@@ -108,7 +194,17 @@ class ArpDomainPersistCase {
 
 		var json = normalizeJson(output.json);
 		// trace(json);
-		assertMatch(PERSIST, Json.parse(json));
+		assertMatch(PERSIST_JSON, Json.parse(json));
+	}
+
+	@Ignore("Verbose output has unordered slots and dirs")
+	public function testWriteSelfVerbose():Void {
+		var output:VerbosePersistOutput = new VerbosePersistOutput();
+		new ArpDomainPersist(domain).writeSelf(output);
+
+		var data = output.data;
+		// trace(data.join(",\n"));
+		assertMatch(PERSIST_VERBOSE, output.data);
 	}
 
 	public function testReadWriteSelf():Void {
@@ -145,8 +241,25 @@ class ArpDomainPersistCase {
 
 		var json = normalizeJson(output.json);
 		// trace(json);
-		assertMatch(PERSIST, Json.parse(json));
+		assertMatch(PERSIST_JSON, Json.parse(json));
 	}
+
+	@Ignore("Verbose output has unordered slots and dirs")
+	public function testWriteReadWriteSelfVerbose():Void {
+		var otherDomain = new ArpDomain();
+		otherDomain.addTemplate(MockArpObject, true);
+
+		var output:VerbosePersistOutput = new VerbosePersistOutput();
+		new ArpDomainPersist(domain).writeSelf(output);
+		new ArpDomainPersist(otherDomain).readSelf(new VerbosePersistInput(output.data));
+		output = new VerbosePersistOutput();
+		new ArpDomainPersist(otherDomain).writeSelf(output);
+
+		var data = output.data;
+		// trace(data.join(",\n"));
+		assertMatch(PERSIST_VERBOSE, output.data);
+	}
+
 
 	private function normalizeJson(json:String):String {
 		// XXX slots and dirs are unordered

--- a/tests/arp/macro/DsMacroArpObjectCase.hx
+++ b/tests/arp/macro/DsMacroArpObjectCase.hx
@@ -78,7 +78,7 @@ class DsMacroArpObjectCase {
 		assertMatch({ro1: arpObj, ro2: arpObj}, OmapOp.toAnon(arpObj.refOmap));
 		assertEquals(8, arpObj.arpSlot.refCount);
 		assertEquals(1, arpObj.arpSlot.primaryDir.refCount);
-		assertEquals(1, domain.root.refCount);
+		assertEquals(2, domain.root.refCount);
 	}
 
 	private function checkIsClone(original:MockDsMacroArpObject, clone:MockDsMacroArpObject):Void {

--- a/tests/arp/macro/DsMacroArpObjectCase.hx
+++ b/tests/arp/macro/DsMacroArpObjectCase.hx
@@ -78,7 +78,7 @@ class DsMacroArpObjectCase {
 		assertMatch({ro1: arpObj, ro2: arpObj}, OmapOp.toAnon(arpObj.refOmap));
 		assertEquals(8, arpObj.arpSlot.refCount);
 		assertEquals(1, arpObj.arpSlot.primaryDir.refCount);
-		assertEquals(2, domain.root.refCount);
+		assertEquals(3, domain.root.refCount);
 	}
 
 	private function checkIsClone(original:MockDsMacroArpObject, clone:MockDsMacroArpObject):Void {

--- a/tests/arp/macro/MacroHierarchicalArpObjectCase.hx
+++ b/tests/arp/macro/MacroHierarchicalArpObjectCase.hx
@@ -45,7 +45,7 @@ class MacroHierarchicalArpObjectCase {
 		assertEquals(null, arpObj.bogusRefField);
 
 		domain.loadSeed(seed);
-		var refFieldDefault = domain.query("default", MOCK_TYPE).value();
+		var refFieldDefault = domain.query("default", MOCK_TYPE).obj();
 		assertEquals(refFieldDefault, arpObj.defaultRefField);
 	}
 

--- a/tests/arp/macro/StdDsMacroArpObjectCase.hx
+++ b/tests/arp/macro/StdDsMacroArpObjectCase.hx
@@ -87,7 +87,7 @@ class StdDsMacroArpObjectCase {
 		assertEquals(arpObj, arpObj.refStdMap.get("key0"));
 		assertEquals(2, arpObj.arpSlot.refCount);
 		assertEquals(1, arpObj.arpSlot.primaryDir.refCount);
-		assertEquals(2, domain.root.refCount);
+		assertEquals(3, domain.root.refCount);
 	}
 
 	private function checkIsClone(original:MockStdDsMacroArpObject, clone:MockStdDsMacroArpObject):Void {

--- a/tests/arp/macro/StdDsMacroArpObjectCase.hx
+++ b/tests/arp/macro/StdDsMacroArpObjectCase.hx
@@ -87,7 +87,7 @@ class StdDsMacroArpObjectCase {
 		assertEquals(arpObj, arpObj.refStdMap.get("key0"));
 		assertEquals(2, arpObj.arpSlot.refCount);
 		assertEquals(1, arpObj.arpSlot.primaryDir.refCount);
-		assertEquals(1, domain.root.refCount);
+		assertEquals(2, domain.root.refCount);
 	}
 
 	private function checkIsClone(original:MockStdDsMacroArpObject, clone:MockStdDsMacroArpObject):Void {

--- a/tests/arp/macro/mocks/MockHierarchicalMacroArpObject.hx
+++ b/tests/arp/macro/mocks/MockHierarchicalMacroArpObject.hx
@@ -6,8 +6,8 @@ import arp.domain.IArpObject;
 class MockHierarchicalMacroArpObject implements IArpObject {
 
 	@:arpField public var refField:MockHierarchicalMacroArpObject;
-	@:arpField @:arpDefault("default") public var defaultRefField:MockHierarchicalMacroArpObject;
-	@:arpField @:arpDefault("bogus") public var bogusRefField:MockHierarchicalMacroArpObject;
+	@:arpField @:arpDefault("/default") public var defaultRefField:MockHierarchicalMacroArpObject;
+	@:arpField @:arpDefault("/bogus") public var bogusRefField:MockHierarchicalMacroArpObject;
 
 	public function new() {
 	}


### PR DESCRIPTION
Resolves #42

Anonymous slots still are not bound to anonRoot, so they are treated as `<anonymous>` (only generated objects which refers `primaryDir` of anonymous slots should go under anonRoot)