### PR TITLE
User template

### DIFF
--- a/src/arp/domain/ArpDomain.hx
+++ b/src/arp/domain/ArpDomain.hx
@@ -184,7 +184,7 @@ class ArpDomain {
 					case [true, ArpOverwriteStrategy.Replace, _] | [false, _, _] | [_, _, true]:
 						factory.arpInit(slot);
 				}
-				arpObj.__arp_loadSeed(seed);
+				factory.arpLoadSeed(arpObj, seed);
 				if (dir != null) this.currentDirStack.pop();
 				if (arpObj != null) {
 					slot.value = arpObj;

--- a/src/arp/domain/ArpDomain.hx
+++ b/src/arp/domain/ArpDomain.hx
@@ -145,8 +145,8 @@ class ArpDomain {
 	public var allArpTypes(get, never):Array<ArpType>;
 	public function get_allArpTypes():Array<ArpType> return this.registry.allArpTypes();
 
-	public function addTemplate<T:IArpObject>(klass:Class<T>, forceDefault:Null<Bool> = null):Void {
-		this.registry.addTemplate(klass, forceDefault);
+	public function addTemplate<T:IArpObject>(template:ArpTemplateLike<T>, forceDefault:Null<Bool> = null):Void {
+		this.registry.addTemplate(template, forceDefault);
 	}
 
 	public function autoAddTemplates():Void {

--- a/src/arp/domain/ArpTemplate.hx
+++ b/src/arp/domain/ArpTemplate.hx
@@ -2,18 +2,13 @@ package arp.domain;
 
 import arp.seed.ArpSeed;
 
-class ArpTemplate<T:IArpObject> {
+class ArpTemplate<T:IArpObject> implements IArpTemplate<T> {
 
 	private var nativeClass:Class<T>;
 
-	public var arpTypeInfo(get, never):ArpTypeInfo;
-	private var _arpTypeInfo:ArpTypeInfo;
-	private function get_arpTypeInfo():ArpTypeInfo {
-		return if (this._arpTypeInfo != null) this._arpTypeInfo else this._arpTypeInfo = this.alloc().arpTypeInfo;
-	}
-
 	public function new(nativeClass:Class<T>) this.nativeClass = nativeClass;
 
+	public function arpTypeInfo():ArpTypeInfo return this.alloc().arpTypeInfo;
 	public function alloc():T return Type.createInstance(nativeClass, []);
 	public function transformSeed(seed:ArpSeed):ArpSeed return seed;
 }

--- a/src/arp/domain/ArpTemplate.hx
+++ b/src/arp/domain/ArpTemplate.hx
@@ -5,10 +5,20 @@ import arp.seed.ArpSeed;
 class ArpTemplate<T:IArpObject> implements IArpTemplate<T> {
 
 	private var nativeClass:Class<T>;
+	private var _arpTypeInfo:ArpTypeInfo;
 
-	public function new(nativeClass:Class<T>) this.nativeClass = nativeClass;
+	public var arpTypeInfo(get, never):ArpTypeInfo;
+	inline private function get_arpTypeInfo():ArpTypeInfo return _arpTypeInfo;
 
-	public function arpTypeInfo():ArpTypeInfo return this.alloc().arpTypeInfo;
+	public function new(nativeClass:Class<T>, overrideName:Null<String> = null) {
+		this.nativeClass = nativeClass;
+		var arpTypeInfo:ArpTypeInfo = this.alloc().arpTypeInfo;
+		if (overrideName != null) {
+			arpTypeInfo = new ArpTypeInfo(overrideName, arpTypeInfo.arpType, arpTypeInfo.overwriteStrategy);
+		}
+		this._arpTypeInfo = arpTypeInfo;
+	}
+
 	public function alloc():T return Type.createInstance(nativeClass, []);
 	public function transformSeed(seed:ArpSeed):ArpSeed return seed;
 }

--- a/src/arp/domain/ArpTemplate.hx
+++ b/src/arp/domain/ArpTemplate.hx
@@ -1,0 +1,19 @@
+package arp.domain;
+
+import arp.seed.ArpSeed;
+
+class ArpTemplate<T:IArpObject> {
+
+	private var nativeClass:Class<T>;
+
+	public var arpTypeInfo(get, never):ArpTypeInfo;
+	private var _arpTypeInfo:ArpTypeInfo;
+	private function get_arpTypeInfo():ArpTypeInfo {
+		return if (this._arpTypeInfo != null) this._arpTypeInfo else this._arpTypeInfo = this.alloc().arpTypeInfo;
+	}
+
+	public function new(nativeClass:Class<T>) this.nativeClass = nativeClass;
+
+	public function alloc():T return Type.createInstance(nativeClass, []);
+	public function transformSeed(seed:ArpSeed):ArpSeed return seed;
+}

--- a/src/arp/domain/ArpTemplateLike.hx
+++ b/src/arp/domain/ArpTemplateLike.hx
@@ -1,0 +1,9 @@
+package arp.domain;
+
+abstract ArpTemplateLike<T:IArpObject>(ArpTemplate<T>) from ArpTemplate<T> to ArpTemplate<T> {
+
+	public function new(template:ArpTemplate<T>) this = template;
+
+	@:from
+	inline public static function concrete<T:IArpObject>(klass:Class<T>):ArpTemplateLike<T> return new ArpTemplate(klass);
+}

--- a/src/arp/domain/ArpTemplateLike.hx
+++ b/src/arp/domain/ArpTemplateLike.hx
@@ -6,4 +6,7 @@ abstract ArpTemplateLike<T:IArpObject>(IArpTemplate<T>) from IArpTemplate<T> to 
 
 	@:from
 	inline public static function concrete<T:IArpObject>(klass:Class<T>):ArpTemplateLike<T> return new ArpTemplate(klass);
+
+	@:from
+	inline public static function fromClass<T:IArpObject>(klass:Class<ArpTemplateLike<T>>):ArpTemplateLike<T> return Type.createInstance(klass, []);
 }

--- a/src/arp/domain/ArpTemplateLike.hx
+++ b/src/arp/domain/ArpTemplateLike.hx
@@ -1,8 +1,8 @@
 package arp.domain;
 
-abstract ArpTemplateLike<T:IArpObject>(ArpTemplate<T>) from ArpTemplate<T> to ArpTemplate<T> {
+abstract ArpTemplateLike<T:IArpObject>(IArpTemplate<T>) from IArpTemplate<T> to IArpTemplate<T> {
 
-	public function new(template:ArpTemplate<T>) this = template;
+	public function new(template:IArpTemplate<T>) this = template;
 
 	@:from
 	inline public static function concrete<T:IArpObject>(klass:Class<T>):ArpTemplateLike<T> return new ArpTemplate(klass);

--- a/src/arp/domain/IArpTemplate.hx
+++ b/src/arp/domain/IArpTemplate.hx
@@ -4,7 +4,8 @@ import arp.seed.ArpSeed;
 
 interface IArpTemplate<T:IArpObject> {
 
-	function arpTypeInfo():ArpTypeInfo;
+	var arpTypeInfo(get, never):ArpTypeInfo;
+
 	function alloc():T;
 	function transformSeed(seed:ArpSeed):ArpSeed;
 }

--- a/src/arp/domain/IArpTemplate.hx
+++ b/src/arp/domain/IArpTemplate.hx
@@ -1,0 +1,10 @@
+package arp.domain;
+
+import arp.seed.ArpSeed;
+
+interface IArpTemplate<T:IArpObject> {
+
+	function arpTypeInfo():ArpTypeInfo;
+	function alloc():T;
+	function transformSeed(seed:ArpSeed):ArpSeed;
+}

--- a/src/arp/domain/factory/ArpObjectFactory.hx
+++ b/src/arp/domain/factory/ArpObjectFactory.hx
@@ -8,7 +8,7 @@ class ArpObjectFactory<T:IArpObject> {
 
 	public var arpTypeInfo(default, null):ArpTypeInfo;
 
-	private var nativeClass:Class<T>;
+	private var arpTemplate:ArpTemplate<T>;
 	private var isDefault:Bool;
 
 	public var overwriteStrategy(default, null):ArpOverwriteStrategy = ArpOverwriteStrategy.Error;
@@ -18,9 +18,9 @@ class ArpObjectFactory<T:IArpObject> {
 	private var className(get, never):String;
 	private function get_className():String return this.arpTypeInfo.name;
 
-	public function new(nativeClass:Class<T>, forceDefault:Null<Bool> = null) {
-		this.nativeClass = nativeClass;
-		this.arpTypeInfo = Type.createEmptyInstance(nativeClass).arpTypeInfo;
+	public function new(arpTemplate:ArpTemplate<T>, forceDefault:Null<Bool> = null) {
+		this.arpTemplate = arpTemplate;
+		this.arpTypeInfo = arpTemplate.arpTypeInfo;
 		this.isDefault = (forceDefault != null) ? forceDefault : this.className == this.arpType.toString();
 		this.overwriteStrategy = this.arpTypeInfo.overwriteStrategy;
 	}
@@ -32,18 +32,15 @@ class ArpObjectFactory<T:IArpObject> {
 		return -1;
 	}
 
-	private function alloc():T {
-		return Type.createInstance(nativeClass, []);
-	}
-
 	public function arpInit(slot:ArpSlot<T>):T {
-		var arpObject:T = alloc();
+		var arpObject:T = this.arpTemplate.alloc();
 		if (arpObject.__arp_init(slot) == null) return null;
 		return arpObject;
 	}
 
 	public function arpLoadSeed(arpObject:T, seed:ArpSeed):T {
-		arpObject.__arp_loadSeed(seed);
+		var s:ArpSeed = this.arpTemplate.transformSeed(seed);
+		arpObject.__arp_loadSeed(s);
 		return arpObject;
 	}
 }

--- a/src/arp/domain/factory/ArpObjectFactory.hx
+++ b/src/arp/domain/factory/ArpObjectFactory.hx
@@ -8,7 +8,7 @@ class ArpObjectFactory<T:IArpObject> {
 
 	public var arpTypeInfo(default, null):ArpTypeInfo;
 
-	private var arpTemplate:ArpTemplate<T>;
+	private var arpTemplate:IArpTemplate<T>;
 	private var isDefault:Bool;
 
 	public var overwriteStrategy(default, null):ArpOverwriteStrategy = ArpOverwriteStrategy.Error;
@@ -18,9 +18,9 @@ class ArpObjectFactory<T:IArpObject> {
 	private var className(get, never):String;
 	private function get_className():String return this.arpTypeInfo.name;
 
-	public function new(arpTemplate:ArpTemplate<T>, forceDefault:Null<Bool> = null) {
+	public function new(arpTemplate:IArpTemplate<T>, forceDefault:Null<Bool> = null) {
 		this.arpTemplate = arpTemplate;
-		this.arpTypeInfo = arpTemplate.arpTypeInfo;
+		this.arpTypeInfo = arpTemplate.arpTypeInfo();
 		this.isDefault = (forceDefault != null) ? forceDefault : this.className == this.arpType.toString();
 		this.overwriteStrategy = this.arpTypeInfo.overwriteStrategy;
 	}

--- a/src/arp/domain/factory/ArpObjectFactory.hx
+++ b/src/arp/domain/factory/ArpObjectFactory.hx
@@ -32,13 +32,18 @@ class ArpObjectFactory<T:IArpObject> {
 		return -1;
 	}
 
-	inline private function alloc():T {
+	private function alloc():T {
 		return Type.createInstance(nativeClass, []);
 	}
 
 	public function arpInit(slot:ArpSlot<T>):T {
 		var arpObject:T = alloc();
 		if (arpObject.__arp_init(slot) == null) return null;
+		return arpObject;
+	}
+
+	public function arpLoadSeed(arpObject:T, seed:ArpSeed):T {
+		arpObject.__arp_loadSeed(seed);
 		return arpObject;
 	}
 }

--- a/src/arp/domain/factory/ArpObjectFactory.hx
+++ b/src/arp/domain/factory/ArpObjectFactory.hx
@@ -20,7 +20,7 @@ class ArpObjectFactory<T:IArpObject> {
 
 	public function new(arpTemplate:IArpTemplate<T>, forceDefault:Null<Bool> = null) {
 		this.arpTemplate = arpTemplate;
-		this.arpTypeInfo = arpTemplate.arpTypeInfo();
+		this.arpTypeInfo = arpTemplate.arpTypeInfo;
 		this.isDefault = (forceDefault != null) ? forceDefault : this.className == this.arpType.toString();
 		this.overwriteStrategy = this.arpTypeInfo.overwriteStrategy;
 	}

--- a/src/arp/domain/factory/ArpObjectFactoryRegistry.hx
+++ b/src/arp/domain/factory/ArpObjectFactoryRegistry.hx
@@ -17,7 +17,7 @@ class ArpObjectFactoryRegistry {
 	}
 
 	public function addTemplate<T:IArpObject>(klass:Class<T>, forceDefault:Null<Bool> = null) {
-		var factory:ArpObjectFactory<T> = new ArpObjectFactory<T>(klass, forceDefault);
+		var factory:ArpObjectFactory<T> = new ArpObjectFactory<T>(new ArpTemplate<T>(klass), forceDefault);
 		if (this.factoriesByFqn.exists(factory.arpTypeInfo.fqn)) return;
 		this.factoriesByArpType.listFor(factory.arpType).push(factory);
 		this.factoriesByFqn.set(factory.arpTypeInfo.fqn, factory);

--- a/src/arp/domain/factory/ArpObjectFactoryRegistry.hx
+++ b/src/arp/domain/factory/ArpObjectFactoryRegistry.hx
@@ -16,8 +16,8 @@ class ArpObjectFactoryRegistry {
 		this.factoriesByFqn = new Map<String, ArpObjectFactory<Dynamic>>();
 	}
 
-	public function addTemplate<T:IArpObject>(klass:Class<T>, forceDefault:Null<Bool> = null) {
-		var factory:ArpObjectFactory<T> = new ArpObjectFactory<T>(new ArpTemplate<T>(klass), forceDefault);
+	public function addTemplate<T:IArpObject>(template:ArpTemplate<T>, forceDefault:Null<Bool> = null) {
+		var factory:ArpObjectFactory<T> = new ArpObjectFactory<T>(template, forceDefault);
 		if (this.factoriesByFqn.exists(factory.arpTypeInfo.fqn)) return;
 		this.factoriesByArpType.listFor(factory.arpType).push(factory);
 		this.factoriesByFqn.set(factory.arpTypeInfo.fqn, factory);

--- a/src/arp/domain/factory/ArpObjectFactoryRegistry.hx
+++ b/src/arp/domain/factory/ArpObjectFactoryRegistry.hx
@@ -16,7 +16,7 @@ class ArpObjectFactoryRegistry {
 		this.factoriesByFqn = new Map<String, ArpObjectFactory<Dynamic>>();
 	}
 
-	public function addTemplate<T:IArpObject>(template:ArpTemplate<T>, forceDefault:Null<Bool> = null) {
+	public function addTemplate<T:IArpObject>(template:IArpTemplate<T>, forceDefault:Null<Bool> = null) {
 		var factory:ArpObjectFactory<T> = new ArpObjectFactory<T>(template, forceDefault);
 		if (this.factoriesByFqn.exists(factory.arpTypeInfo.fqn)) return;
 		this.factoriesByArpType.listFor(factory.arpType).push(factory);

--- a/tests/arp/ArpDomainTestSuite.hx
+++ b/tests/arp/ArpDomainTestSuite.hx
@@ -4,6 +4,7 @@ import arp.domain.ArpDirectoryCase;
 import arp.domain.ArpDomainCase;
 import arp.domain.ArpDomainPersistCase;
 import arp.domain.MockArpObjectCase;
+import arp.domain.MockArpTemplateCase;
 import arp.domain.MockDerivedArpObjectCase;
 import arp.domain.query.ArpDirectoryQueryCase;
 import arp.domain.query.ArpObjectQueryCase;
@@ -35,6 +36,7 @@ class ArpDomainTestSuite {
 
 		r.load(MockArpObjectCase);
 		r.load(MockDerivedArpObjectCase);
+		r.load(MockArpTemplateCase);
 
 		r.load(MacroArpObjectCase);
 		r.load(MacroDefaultArpObjectCase);

--- a/tests/arp/domain/MockArpTemplateCase.hx
+++ b/tests/arp/domain/MockArpTemplateCase.hx
@@ -1,0 +1,65 @@
+package arp.domain;
+
+import arp.domain.mocks.MockArpTemplate;
+import arp.domain.ArpSlot;
+import arp.domain.core.ArpType;
+import arp.domain.mocks.MockArpObject;
+import arp.seed.ArpSeed;
+import arp.tests.ArpDomainTestUtil;
+import picotest.PicoAssert.*;
+
+class MockArpTemplateCase {
+
+	private var domain:ArpDomain;
+	private var slot:ArpSlot<MockArpObject>;
+	private var arpObj:MockArpObject;
+	private var xml:Xml;
+	private var seed:ArpSeed;
+
+	public function setup():Void {
+		domain = new ArpDomain();
+		domain.addTemplate(MockArpTemplate, true);
+		xml = Xml.parse('<mock class="override" name="name1" intField="42" floatField="3.14" boolField="true" stringField="stringValue" refField="/name1" />').firstElement();
+		seed = ArpSeed.fromXml(xml);
+	}
+
+	public function testLoadSeed():Void {
+		slot = domain.loadSeed(seed, new ArpType("mock"));
+		arpObj = slot.value;
+
+		assertEquals(42, arpObj.intField);
+		assertEquals(3.14, arpObj.floatField);
+		assertEquals(true, arpObj.boolField);
+		assertEquals("stringValue", arpObj.stringField);
+		assertEquals(arpObj, arpObj.refField);
+		assertEquals("mock", arpObj.arpTypeInfo.name);
+	}
+
+	private function checkIsClone(original:MockArpObject, clone:MockArpObject):Void {
+		assertEquals(original.arpDomain, clone.arpDomain);
+		assertEquals(original.arpType, clone.arpType);
+		assertNotEquals(original.arpSlot, clone.arpSlot);
+
+		assertEquals(original.intField, clone.intField);
+		assertEquals(original.floatField, clone.floatField);
+		assertEquals(original.boolField, clone.boolField);
+		assertEquals(original.stringField, clone.stringField);
+		assertEquals(original.refField, clone.refField);
+	}
+
+	public function testPersistable():Void {
+		slot = domain.loadSeed(seed, new ArpType("mock"));
+		arpObj = slot.value;
+
+		var clone:MockArpObject = ArpDomainTestUtil.roundTrip(domain, arpObj, MockArpObject);
+		checkIsClone(arpObj, clone);
+	}
+
+	public function testClone():Void {
+		slot = domain.loadSeed(seed, new ArpType("mock"));
+		arpObj = slot.value;
+
+		var clone:MockArpObject = cast arpObj.arpClone();
+		checkIsClone(arpObj, clone);
+	}
+}

--- a/tests/arp/domain/mocks/MockArpTemplate.hx
+++ b/tests/arp/domain/mocks/MockArpTemplate.hx
@@ -1,0 +1,18 @@
+package arp.domain.mocks;
+
+import arp.domain.core.ArpOverwriteStrategy;
+import arp.domain.core.ArpType;
+import arp.domain.ArpTypeInfo;
+import arp.seed.ArpSeed;
+
+class MockArpTemplate implements IArpTemplate<MockArpObject> {
+
+	public var arpTypeInfo(get, never):ArpTypeInfo;
+	private var _arpTypeInfo:ArpTypeInfo;
+	public function get_arpTypeInfo():ArpTypeInfo return new ArpTypeInfo("override", new ArpType("mock"), ArpOverwriteStrategy.Error);
+
+	public function alloc():MockArpObject return new MockArpObject();
+	public function transformSeed(seed:ArpSeed):ArpSeed return seed;
+
+	public function new() return;
+}


### PR DESCRIPTION
Part of #9 (rest goes to ArpEngine/ArpSupport)

`ArpDomain.addTemplate()` accepts `ArpTemplateLike<T>` instead of `Class<T>`.

Seed structure should be injected in user implemented `ArpTemplate<T>`s (not possible with current ArpSupport)